### PR TITLE
exclude Intercom.xcframework files

### DIFF
--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/intercom/intercom-react-native.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"
+  s.exclude_files = "ios/Intercom.xcframework/**/*"
   s.resource_bundles = { 'IntercomFramework' => ['ios/assets/*'] }
 
   s.dependency "React-Core"


### PR DESCRIPTION
Hello! I've faced huge warning when installing pods. You could run `pod install` in example/ios in the main branch to see the warning.

<img width="1189" alt="Screenshot 2021-08-25 at 17 22 50" src="https://user-images.githubusercontent.com/726880/130808860-f0831bd1-6f7d-418a-aac3-f070d16e0a6c.png">

I'm not an iOS developer, but this fix works for me. Could you check it?