### PR TITLE
Fix incompatible method signatures

### DIFF
--- a/ios/IntercomModule.h
+++ b/ios/IntercomModule.h
@@ -2,7 +2,7 @@
 
 @interface IntercomModule : NSObject <RCTBridgeModule>
 + (void)initialize:(nonnull NSString *)apiKey withAppId:(nonnull NSString *)appId;
-+ (void)setDeviceToken:(nonnull NSString *)deviceToken;
++ (void)setDeviceToken:(nonnull NSData *)deviceToken;
 + (BOOL)isIntercomPushNotification:(nonnull NSDictionary *)userInfo;
 + (void)handleIntercomPushNotification:(nonnull NSDictionary *)userInfo;
 - (NSError *)exceptionToError:(NSException *)exception :(NSString *)code :(NSString *)domain;

--- a/ios/IntercomModule.m
+++ b/ios/IntercomModule.m
@@ -48,12 +48,12 @@ RCT_EXPORT_MODULE()
     NSLog(@"setDeviceToken");
 }
 
-+ (BOOL)isIntercomPushNotification:(NSDictionary *)userInfo {
++ (BOOL)isIntercomPushNotification:(nonnull NSDictionary *)userInfo {
 
     return [Intercom isIntercomPushNotification:userInfo];
 }
 
-+ (void)handleIntercomPushNotification:(NSDictionary *)userInfo {
++ (void)handleIntercomPushNotification:(nonnull NSDictionary *)userInfo {
     [Intercom handleIntercomPushNotification:userInfo];
 }
 


### PR DESCRIPTION
The `setDeviceToken` method has different signatures in the `.h` and `.m` files. As a result, when configuring push notifications using the native `didRegisterForRemoteNotificationsWithDeviceToken` delegate method, there is a build error in Xcode 12.5.1:

<img width="800" alt="Screenshot 2021-10-13 at 14 12 42" src="https://user-images.githubusercontent.com/820863/137162342-45d622d6-3675-4a15-bd2e-65af544847c4.png">

It seems that the method signature for this was changed in the `.m` file, but not in the corresponding `.h` file. Since Xcode uses the header file during compilation, this appears to be causing a compile-time error.

This PR changes the `.h` file to be brought into line with the `.m` implementation. There are also a couple of `nonnull` keywords that were present in the `.h` file, that have been mirrored in `.m` for completion.
