### PR TITLE
ios: Fix RCTEventEmitter import for Expo 44+

### DIFF
--- a/ios/IntercomEventEmitter.h
+++ b/ios/IntercomEventEmitter.h
@@ -1,10 +1,4 @@
-#if __has_include("RCTEventEmitter.h")
-
-#import "RCTEventEmitter.h"
-
-#else
 #import <React/RCTEventEmitter.h>
-#endif
 
 @interface IntercomEventEmitter : RCTEventEmitter
 @end


### PR DESCRIPTION
When a project is using Swift modules (like Expo 44+), then imports must use the `React/<header>.h` form, otherwise you get a compiler error: `duplicate interface definition for class 'RCTEventEmitter'`

This change should be comptabtible with React 40+, which introducedthe `React/` headers.

See https://github.com/expo/expo/issues/15622#issuecomment-997225774 for the detailed investigation and fix.

Here is a similar change in another package: https://github.com/LinusU/react-native-get-random-values/pull/33