### PR TITLE
fix: HelpCenterArticle typings

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -78,7 +78,7 @@ export type Company = {
 };
 
 export type HelpCenterArticle = { id: string; title: string };
-export type HelpCenterSection = { title: string; articles: HelpCenterArticle };
+export type HelpCenterSection = { title: string; articles: HelpCenterArticle[] };
 export type HelpCenterCollectionItem = {
   id: string;
   title: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -77,7 +77,7 @@ export type Company = {
   plan?: string;
 };
 
-export type HelpCenterArticle = { it: string; title: string };
+export type HelpCenterArticle = { id: string; title: string };
 export type HelpCenterSection = { title: string; articles: HelpCenterArticle };
 export type HelpCenterCollectionItem = {
   id: string;


### PR DESCRIPTION
I believe the typings are incorrect on the `HelpCenterArticle` type exposed in index.d.ts.

 Fetching a collection with `Intercom.fetchHelpCenterCollection("COLLECTION_ID")` returns `id` and `title` props. But types are declared as `it` and `title`
```
// Returned value from fetchHelpCenterCollection
{"articles": [
{"id": "1234", "title": "Article 1"}, 
{"id": "5678", "title": "Article 2"}]
```

Version: 1.1.1

Feel free to close this if I'm out sailing. Have good one :) 