### PR TITLE
fix: allow null custom attributes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,7 +50,7 @@ type EventType =
   | 'IntercomWindowDidShowNotification';
 
 export type CustomAttributes = {
-  [key: string]: boolean | string | number;
+  [key: string]: boolean | string | number | null;
 };
 export type MetaData = {
   [key: string]: any;


### PR DESCRIPTION
This PR adds ```null``` as an accepted custom attribute value since the documentation states it should be used when the value is unknown.