### PR TITLE
Correct unread count event listener for Android

### DIFF
--- a/android/src/main/java/com/intercom/reactnative/IntercomEventEmitter.java
+++ b/android/src/main/java/com/intercom/reactnative/IntercomEventEmitter.java
@@ -20,7 +20,7 @@ import io.intercom.android.sdk.UnreadConversationCountListener;
 public class IntercomEventEmitter extends ReactContextBaseJavaModule {
 
   private static final String NAME = "IntercomEventEmitter";
-  private static final String UNREAD_COUNT_CHANGE_NOTIFICATION = "IntercomUnreadCountDidChange";
+  private static final String UNREAD_COUNT_CHANGE_NOTIFICATION = "IntercomUnreadConversationCountDidChangeNotification";
   private int activeListenersCount = 0;
   private final UnreadConversationCountListener unreadConversationCountListener = new UnreadConversationCountListener() {
     @Override


### PR DESCRIPTION
The event name in the documentation only seems to apply to iOS, this fix will allow it to work on Android also.