### PR TITLE
Expose context vars in build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,8 @@ workflows:
   build-and-test:
     jobs:
       - install-dependencies:
+          context:
+            - react-native-context
           <<: *run_always
       - lint:
           <<: *run_always


### PR DESCRIPTION
This won't be merged, just using it to get at some vars