### PR TITLE
fix: Update types for HelpCenterCollections (iOS bug)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -477,7 +477,7 @@ interface Survey extends Content {
 }
 
 interface HelpCenterCollections extends Content {
-  ids: string[];
+  ids: string | string[];
 }
 
 export type IntercomContentType = {
@@ -488,7 +488,7 @@ export type IntercomContentType = {
   carouselWithCarouselId: (carouselId: string) => Carousel;
   surveyWithSurveyId: (surveyId: string) => Survey;
   helpCenterCollectionsWithIds: (
-    collectionIds: string[]
+    collectionIds: string | string[]
   ) => HelpCenterCollections;
 };
 


### PR DESCRIPTION
Hi there,

I wanted to bring to your attention a bug we encountered after updating the SDK to version v4.0.1. We found that using `IntercomContent.helpCenterCollectionsWithIds` within a call to `Intercom.presentContent` would not trigger the Intercom bottom sheet overlay that we are accustomed to seeing.

We have identified that the issue is exclusive to iOS. While `helpCenterCollectionsWithIds` input parameter is of type `string[]`, passing in an array of string values (collectionIds) fails to trigger the Intercom overlay on iOS. As a temporary workaround, we have been passing through a single collectionId which breaks the typing convention, but it opens the Intercom overlay - it's only a workaround for what we believe to be a bug on the iOS side of the SDK.

To illustrate, I have included a screenshot of how we are currently handling the issue:

![Screenshot 2023-05-03 at 10 20 59](https://user-images.githubusercontent.com/12637812/235878505-a2decc08-d258-400b-8191-8710071d0319.png)

Ultimately, solution is to enable passing an array of collectionIds for iOS and having the Intercom overlay trigger as expected. This pull request is meant to serve as a notification of the potential bug.


Cheers!
