### PR TITLE
fix: present the help center collection by ids on ios

### DIFF
--- a/ios/IntercomModule.m
+++ b/ios/IntercomModule.m
@@ -81,7 +81,7 @@ RCT_EXPORT_METHOD(sendTokenToIntercom:(NSString *)token
         [Intercom setDeviceToken:data failure:^(NSError * _Nullable error) {
             reject(SEND_TOKEN_TO_INTERCOM, @"Error in sendTokenToIntercom", error);
         }];
-        
+
         resolve(@(YES));
     } @catch (NSException *exception) {
         reject(SEND_TOKEN_TO_INTERCOM, @"Error in sendTokenToIntercom", [self exceptionToError:exception :SEND_TOKEN_TO_INTERCOM :@"sendTokenToIntercom"]);
@@ -215,8 +215,7 @@ RCT_EXPORT_METHOD(presentContent:(NSDictionary *)content
     } else if ([contentType isEqualToString:@"SURVEY"]) {
         intercomContent = [IntercomContent surveyWithId:content[@"id"]];
     } else if ([contentType isEqualToString:@"HELP_CENTER_COLLECTIONS"]) {
-        NSArray<NSString *> *collectionIds = [NSArray arrayWithObjects:content[@"ids"], nil];
-        intercomContent = [IntercomContent helpCenterCollectionsWithIds:collectionIds];
+        intercomContent = [IntercomContent helpCenterCollectionsWithIds:content[@"ids"]];
     }
     if (intercomContent) {
         [Intercom presentContent:intercomContent];
@@ -229,7 +228,7 @@ RCT_EXPORT_METHOD(presentContent:(NSDictionary *)content
 
 RCT_EXPORT_METHOD(fetchHelpCenterCollections:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     [Intercom fetchHelpCenterCollectionsWithCompletion:^(NSArray<ICMHelpCenterCollection *> *_Nullable collections, NSError *_Nullable error) {
-        
+
         if (collections != nil) {
             NSArray *parsedCollections = [IntercomHelpCenterHelpers parseCollectionsToArray:collections];
             resolve(parsedCollections);


### PR DESCRIPTION
This pull request addresses an issue with the Intercom React Native 4.0.1 SDK on iOS, where collections are not being displayed. This issue has been previously reported by the Intercom engineering team and other users on the Intercom forum: https://forum.intercom.com/s/question/0D55c00006mnnnLCAQ/cant-display-collections-using-intercomreactnative-401-mobile-sdk

After investigating the code, I found that the promise was resolving and that the code was not breaking or crashing. However, I discovered that the logic in the code was incorrect, leading to the issue. As a result, I made changes to the logic to fix the problem. These changes should resolve the collection display issue for all affected users.

Let me know if you have any further questions or if you would like any further help!

