### PR TITLE
Fix multiple collections display on React Native [iOS]

### DIFF
--- a/ios/IntercomModule.m
+++ b/ios/IntercomModule.m
@@ -215,7 +215,7 @@ RCT_EXPORT_METHOD(presentContent:(NSDictionary *)content
     } else if ([contentType isEqualToString:@"SURVEY"]) {
         intercomContent = [IntercomContent surveyWithId:content[@"id"]];
     } else if ([contentType isEqualToString:@"HELP_CENTER_COLLECTIONS"]) {
-        NSArray<NSString *> *collectionIds = [NSArray arrayWithObjects:content[@"ids"], nil];
+        NSArray<NSString *> *collectionIds = content[@"ids"];
         intercomContent = [IntercomContent helpCenterCollectionsWithIds:collectionIds];
     }
     if (intercomContent) {


### PR DESCRIPTION
# What?
Closes https://github.com/intercom/intercom/issues/265749

# Why?
Our [documentation](https://developers.intercom.com/installing-intercom/docs/help-center-api-react-native#present-a-filtered-help-center) says that we can show a list of specific collection using:
```javascript
Intercom.presentContent(
      IntercomContent.helpCenterCollectionsWithIds(['123','456'])
);
```
But unfortunately, this does not work on iOS since we are expecting a comma-separated list of objects, rather than an array itself.

# How?
This change fixes the expectation of receiving the collection ids in the form of an array.

**Viewing a single collection:**

https://github.com/intercom/intercom-react-native/assets/15261102/ba6cc1bc-3d65-404b-83db-eb2eb16347d6

**Viewing 2 collections:**

https://github.com/intercom/intercom-react-native/assets/15261102/aabda6a9-e5f6-49ec-b89e-4af32489f053

