### PR TITLE
Handle loginUserWithUserAttributes with only userId

### DIFF
--- a/android/src/main/java/com/intercom/reactnative/IntercomModule.java
+++ b/android/src/main/java/com/intercom/reactnative/IntercomModule.java
@@ -136,12 +136,14 @@ public class IntercomModule extends ReactContextBaseJavaModule {
     Boolean hasEmail = params.hasKey("email") && IntercomHelpers.getValueAsStringForKey(params, "email").length() > 0;
     Boolean hasUserId = params.hasKey("userId") && IntercomHelpers.getValueAsStringForKey(params, "userId").length() > 0;
     Registration registration = null;
-    String email = IntercomHelpers.getValueAsStringForKey(params, "email");
     String userId = IntercomHelpers.getValueAsStringForKey(params, "userId");
-    if (hasEmail && hasUserId) {
-      registration = new Registration().withEmail(email).withUserId(userId);
-    } else if (hasEmail) {
-      registration = Registration.create().withEmail(email);
+    if (hasEmail) {
+      String email = IntercomHelpers.getValueAsStringForKey(params, "email");
+      if (hasUserId) {
+        registration = new Registration().withEmail(email).withUserId(userId);
+      } else {
+        registration = Registration.create().withEmail(email);
+      }
     } else if (hasUserId) {
       registration = Registration.create().withUserId(userId);
     } else {


### PR DESCRIPTION
See https://community.intercom.com/mobile-sdks-24/react-native-crash-on-android-for-latest-version-5-0-0-4482

Since [this](https://github.com/intercom/intercom-react-native/commit/505d1c0883b8928d28d29be3f3a03aa48023ea52) commit, if you send `loginUserWithUserAttributes({ userId })` you get a crash on android:

```
com.facebook.react.bridge.NoSuchKeyException: email
    at com.facebook.react.bridge.ReadableNativeMap.getType(ReadableNativeMap.java:183)
    at com.intercom.reactnative.IntercomHelpers.getValueAsStringForKey(IntercomHelpers.java:227)
    at com.intercom.reactnative.IntercomModule.loginUserWithUserAttributes(IntercomModule.java:139)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
    at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:188)
    at com.facebook.jni.NativeRunnable.run(NativeRunnable.java)
    at android.os.Handler.handleCallback(Handler.java:942)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
    at android.os.Looper.loopOnce(Looper.java:226)
    at android.os.Looper.loop(Looper.java:313)
    at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:228)
    at java.lang.Thread.run(Thread.java:1012)
```