### PR TITLE
fix: Do not query for userId when it is not present

### DIFF
--- a/android/src/main/java/com/intercom/reactnative/IntercomModule.java
+++ b/android/src/main/java/com/intercom/reactnative/IntercomModule.java
@@ -136,16 +136,16 @@ public class IntercomModule extends ReactContextBaseJavaModule {
     Boolean hasEmail = params.hasKey("email") && IntercomHelpers.getValueAsStringForKey(params, "email").length() > 0;
     Boolean hasUserId = params.hasKey("userId") && IntercomHelpers.getValueAsStringForKey(params, "userId").length() > 0;
     Registration registration = null;
-    String userId = IntercomHelpers.getValueAsStringForKey(params, "userId");
-    if (hasEmail) {
+    if (hasEmail && hasUserId) {
       String email = IntercomHelpers.getValueAsStringForKey(params, "email");
-      if (hasUserId) {
-        registration = new Registration().withEmail(email).withUserId(userId);
-      } else {
-        registration = Registration.create().withEmail(email);
-      }
+      String userId = IntercomHelpers.getValueAsStringForKey(params, "userId");
+      registration = new Registration().withEmail(email).withUserId(userId);
+    } else if (hasEmail) {
+      String email = IntercomHelpers.getValueAsStringForKey(params, "email");
+      registration = new Registration().withEmail(email);
     } else if (hasUserId) {
-      registration = Registration.create().withUserId(userId);
+      String userId = IntercomHelpers.getValueAsStringForKey(params, "userId");
+      registration = new Registration().withUserId(userId);
     } else {
       Log.e(NAME, "loginUserWithUserAttributes called with invalid userId or email");
       Log.e(NAME, "You must provide userId or email");

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -74,7 +74,7 @@ PODS:
   - fmt (6.2.1)
   - glog (0.3.5)
   - Intercom (15.0.0)
-  - intercom-react-native (5.0.0):
+  - intercom-react-native (5.1.1):
     - Intercom (~> 15.0.0)
     - React-Core
   - libevent (2.1.12)
@@ -534,7 +534,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   Intercom: c4d9286eb12277dd104e7a49aead819337772716
-  intercom-react-native: 83a85583016a294827177465301795ec46e5a310
+  intercom-react-native: a9174e41c57228fa94ee832f771b6977826254a3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda


### PR DESCRIPTION
We were querying for `userId` without checking for `hasUserId` first since [this commit ](https://github.com/intercom/intercom-react-native/pull/102/commits/525c5798d42dc2088ce22f65ec042f6810792a6c)on [this line](https://github.com/intercom/intercom-react-native/pull/102/files#diff-10ce8b0b8276fea3d60e8398e5e5414a49111b89a0f12e4c34245d2620b4d093R139)

This PR fixes that.

`loginUserWithUserAttributes` should now work in all 3 cases :
- with both `email` and `userId`
- with only `email`
- with only `userId`