### PR TITLE
Update Intercom iOS version to 15.0.2

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -73,9 +73,9 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Intercom (15.0.0)
-  - intercom-react-native (5.1.1):
-    - Intercom (~> 15.0.0)
+  - Intercom (15.0.1)
+  - intercom-react-native (5.1.2):
+    - Intercom (~> 15.0.1)
     - React-Core
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
@@ -533,8 +533,8 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  Intercom: c4d9286eb12277dd104e7a49aead819337772716
-  intercom-react-native: a9174e41c57228fa94ee832f771b6977826254a3
+  Intercom: fb5a9c701c04d10379b6db4cdc96028ca1b09bea
+  intercom-react-native: 85fd0015e139de7e3de7e099acd464402084edae
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -73,9 +73,9 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Intercom (15.0.1)
+  - Intercom (15.0.2)
   - intercom-react-native (5.1.2):
-    - Intercom (~> 15.0.1)
+    - Intercom (~> 15.0.2)
     - React-Core
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
@@ -533,8 +533,8 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  Intercom: fb5a9c701c04d10379b6db4cdc96028ca1b09bea
-  intercom-react-native: 85fd0015e139de7e3de7e099acd464402084edae
+  Intercom: bb499c2bdeacaabb498c94572afa5fcfd74294eb
+  intercom-react-native: 00d89b6267abc4470949a071bfac4550fbeb6deb
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda

--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'IntercomFramework' => ['ios/assets/*'] }
 
   s.dependency "React-Core"
-  s.dependency "Intercom", '~> 15.0.0'
+  s.dependency "Intercom", '~> 15.0.1'
 end

--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'IntercomFramework' => ['ios/assets/*'] }
 
   s.dependency "React-Core"
-  s.dependency "Intercom", '~> 15.0.1'
+  s.dependency "Intercom", '~> 15.0.2'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
This updates intercom-react-native to use [version 15.0.2 of the iOS SDK](https://github.com/intercom/intercom-ios/releases/tag/15.0.2)