### PR TITLE
Remove deprecated to displayMessenger

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -329,9 +329,6 @@ export type IntercomType = {
    */
   updateUser(params: UpdateUserParamList): Promise<boolean>;
 
-  /**
-   * @deprecated `displayMessenger` is deprecated and will be removed in a future release.  Use `presentIntercom` instead.
-   */
   displayMessenger(): Promise<boolean>;
 
   /**


### PR DESCRIPTION
displayMessenger is mark as deprecated but is not. This says use _presentIntercom instead_ but is undefined