### PR TITLE
Make android stick to 15.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,5 +60,5 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '20.2.+')}"
-    implementation 'io.intercom.android:intercom-sdk:15.2.+'
+    implementation 'io.intercom.android:intercom-sdk:15.2.0'
 }


### PR DESCRIPTION
- React native wrapper picks the latest patch version of android (15.2.1)
- Android sdk 15.2.1 targets compileSDK 34.

So we want to make it to stick to using 15.2.0 for now