### PR TITLE
Remove `NSUnderlyingErrorKey` when it is an `NSNull` object

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -74,7 +74,7 @@ PODS:
   - fmt (6.2.1)
   - glog (0.3.5)
   - Intercom (16.0.1)
-  - intercom-react-native (5.3.1):
+  - intercom-react-native (6.0.0):
     - Intercom (~> 16.0.1)
     - React-Core
   - libevent (2.1.12)
@@ -519,7 +519,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: bc76253beb7463b688aa6af913b822ed631de31a
   FBReactNativeSpec: 85d34420d92cb178897de05e3aba90e7a8568162
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -532,9 +532,9 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   Intercom: 62fe4d94519fba99f17df3f7a0c62dc7dbcb7b02
-  intercom-react-native: bfa2ea64fba2b38f3b0c48afe020b05ac0007cb3
+  intercom-react-native: 7bf5734cca0629303b514e188e60d7d87c17338c
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda

--- a/ios/IntercomModule.m
+++ b/ios/IntercomModule.m
@@ -351,7 +351,6 @@ RCT_EXPORT_METHOD(setNeedsStatusBarAppearanceUpdate:(RCTPromiseResolveBlock)reso
 };
 
 - (NSError *)exceptionToError:(NSException *)exception :(NSString *)code :(NSString *)domain {
-//    self removeNullUnderlyingError:
     NSMutableDictionary *info = [NSMutableDictionary dictionary];
     [info setValue:exception.name forKey:@"ExceptionName"];
     [info setValue:exception.reason forKey:@"ExceptionReason"];

--- a/ios/IntercomModule.m
+++ b/ios/IntercomModule.m
@@ -100,7 +100,7 @@ RCT_EXPORT_METHOD(loginUnidentifiedUser:(RCTPromiseResolveBlock)successCallback
     [Intercom loginUnidentifiedUserWithSuccess:^{
         successCallback(@(YES));
     } failure:^(NSError * _Nonnull error) {
-        failureCallback(error);
+        failureCallback([self removeNullUnderlyingError:error]);
     }];
 };
 
@@ -119,7 +119,7 @@ RCT_EXPORT_METHOD(loginUserWithUserAttributes:(NSDictionary *)userAttributes
     [Intercom loginUserWithUserAttributes:attributes success:^{
         successCallback(@(YES));
     } failure:^(NSError * _Nonnull error) {
-        failureCallback(error);
+        failureCallback([self removeNullUnderlyingError:error]);
     }];
 }
 
@@ -135,7 +135,7 @@ RCT_EXPORT_METHOD(updateUser:(NSDictionary *)userAttributesDict
     [Intercom updateUser:userAttributes success:^{
         resolve(@(YES));
     } failure:^(NSError * _Nonnull error) {
-        failureCallback(error);
+        failureCallback([self removeNullUnderlyingError:error]);
     }];
 };
 
@@ -351,6 +351,7 @@ RCT_EXPORT_METHOD(setNeedsStatusBarAppearanceUpdate:(RCTPromiseResolveBlock)reso
 };
 
 - (NSError *)exceptionToError:(NSException *)exception :(NSString *)code :(NSString *)domain {
+//    self removeNullUnderlyingError:
     NSMutableDictionary *info = [NSMutableDictionary dictionary];
     [info setValue:exception.name forKey:@"ExceptionName"];
     [info setValue:exception.reason forKey:@"ExceptionReason"];
@@ -359,5 +360,21 @@ RCT_EXPORT_METHOD(setNeedsStatusBarAppearanceUpdate:(RCTPromiseResolveBlock)reso
     [info setValue:exception.userInfo forKey:@"ExceptionUserInfo"];
 
     return [[NSError alloc] initWithDomain:domain code:[code integerValue] userInfo:info];
+};
+
+
+/// Remove `NSUnderlyingErrorKey` from the `userInfo` if its value is  of type `NSNull`
+///
+/// NSErrors that are return from Intercom can have a value of `NSNull`. ReactNative is unable to handle this so we
+/// strip them out to avoid crashing the app.
+/// - Parameter error: the `NSError` object.
+- (NSError *)removeNullUnderlyingError:(NSError *)error {
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+    NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
+    [userInfo addEntriesFromDictionary:error.userInfo];
+    if([underlyingError isKindOfClass:[NSNull class]]) {
+        [userInfo removeObjectForKey:NSUnderlyingErrorKey];
+    }
+    return [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:userInfo];
 };
 @end


### PR DESCRIPTION
- NSErrors that are return from Intercom can have a value of `NSNull`. ReactNative is unable to handle this so we
strip them out to avoid crashing the app.