### PR TITLE
Login user with actual attributes

### DIFF
--- a/ios/IntercomModule.m
+++ b/ios/IntercomModule.m
@@ -107,7 +107,6 @@ RCT_EXPORT_METHOD(loginUnidentifiedUser:(RCTPromiseResolveBlock)successCallback
 RCT_EXPORT_METHOD(loginUserWithUserAttributes:(NSDictionary *)userAttributes
                                       success:(RCTPromiseResolveBlock)successCallback
                                       failure:(RCTResponseErrorBlock)failureCallback) {
-    // Use the IntercomAttributesBuilder to create ICMUserAttributes from the dictionary
     ICMUserAttributes *attributes = [IntercomAttributesBuilder userAttributesForDictionary:userAttributes];
 
     [Intercom loginUserWithUserAttributes:attributes success:^{
@@ -197,7 +196,7 @@ RCT_EXPORT_METHOD(presentIntercomSpace:(NSString *)space
         selectedSpace = messages;
     } else if ([space isEqualToString:@"TICKETS"]) {
         selectedSpace = tickets;
-    } 
+    }
     [Intercom presentIntercom:selectedSpace];
     RCTLog(@"Presenting Intercom Space : %@", space);
     resolve(@(YES));

--- a/ios/IntercomModule.m
+++ b/ios/IntercomModule.m
@@ -107,15 +107,9 @@ RCT_EXPORT_METHOD(loginUnidentifiedUser:(RCTPromiseResolveBlock)successCallback
 RCT_EXPORT_METHOD(loginUserWithUserAttributes:(NSDictionary *)userAttributes
                                       success:(RCTPromiseResolveBlock)successCallback
                                       failure:(RCTResponseErrorBlock)failureCallback) {
-    NSString *userId = userAttributes[@"userId"];
-    NSString *userEmail = userAttributes[@"email"];
+    // Use the IntercomAttributesBuilder to create ICMUserAttributes from the dictionary
+    ICMUserAttributes *attributes = [IntercomAttributesBuilder userAttributesForDictionary:userAttributes];
 
-    if ([userId isKindOfClass:[NSNumber class]]) {
-        userId = [(NSNumber *) userId stringValue];
-    }
-    ICMUserAttributes *attributes = [ICMUserAttributes new];
-    attributes.userId = userId;
-    attributes.email = userEmail;
     [Intercom loginUserWithUserAttributes:attributes success:^{
         successCallback(@(YES));
     } failure:^(NSError * _Nonnull error) {


### PR DESCRIPTION
This PR updates `loginUserWithUserAttributes` to use `IntercomAttributesBuilder` when passing in additional attributes for a new user, just as `updateUser` does. This is iOS only as I haven't updated the Android method yet.

The parameter typing on `loginUserWithUserAttributes` shows the full `UserAttributes` object, but the underlying methods only retain `userId` and `email` and discard the rest, which is confusing when passing in additional data and not seeing it on the dashboard. Previously this also required two round-trips, one for initial login and another to update the created user's attributes.

If this isn't the desired behavior I'd be happy to instead update the `loginUserWithUserAttributes` types to require only `userId` _or_ `email`.