### PR TITLE
fix: add namespace for AGP <4.2 support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,8 +23,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    // Compatibility for AGP v. <4.2
-    namespace 'io.intercom.android'
+    // Compatibility for AGP v. <4.2/Gradle 8
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpVersion >= 7) {
+      namespace 'com.intercom.reactnative'
+    }
 
     compileSdkVersion safeExtGet('IntercomReactNative_compileSdkVersion', 34)
     defaultConfig {
@@ -43,9 +46,12 @@ android {
     lintOptions {
         disable 'GradleCompatible'
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+
+    if (agpVersion < 8) {
+      compileOptions {
+          sourceCompatibility JavaVersion.VERSION_1_8
+          targetCompatibility JavaVersion.VERSION_1_8
+      }
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,9 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+    // Compatibility for AGP v. <4.2
+    namespace 'io.intercom.android'
+
     compileSdkVersion safeExtGet('IntercomReactNative_compileSdkVersion', 34)
     defaultConfig {
         minSdkVersion safeExtGet('IntercomReactNative_minSdkVersion', 21)

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.intercom.reactnative">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
For AGP versions greater than 4.2, it requires a namespace. Without this, versions higher than AGP 4.2 will result in this error 

```
* What went wrong:
A problem occurred configuring project ':intercom_intercom-react-native'.
  ...
   > Namespace not specified. Specify a namespace in the module's build file.
```

Hope you have a good day!