### PR TITLE
Update version to 6.5.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,5 +69,5 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '20.2.+')}"
-    implementation 'io.intercom.android:intercom-sdk:15.4.0'
+    implementation 'io.intercom.android:intercom-sdk:15.6.3'
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -73,9 +73,9 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Intercom (16.5.1)
-  - intercom-react-native (6.4.0):
-    - Intercom (~> 16.5.1)
+  - Intercom (16.5.6)
+  - intercom-react-native (6.5.0):
+    - Intercom (~> 16.5.6)
     - React-Core
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
@@ -533,8 +533,8 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  Intercom: e1201b00236d1af21b14905c17f25bda62336c78
-  intercom-react-native: 2153ba15459084eb2b455cc6fcbe5889c5c5cb40
+  Intercom: d6f58ff03af158108d8a2f4433e7b91471c0af34
+  intercom-react-native: e6b978ac79de235a054aa91f6dde7648689ac837
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda

--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'IntercomFramework' => ['ios/assets/*'] }
 
   s.dependency "React-Core"
-  s.dependency "Intercom", '~> 16.5.1'
+  s.dependency "Intercom", '~> 16.5.6'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "6.4.1",
+  "version": "6.5.0",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# Why?
- Updates react native version from 6.4.0 to 6.5.0 for the new expo update.
- Updates iOS SDK to [16.5.6](https://github.com/intercom/intercom-ios/releases/tag/16.5.6)
- Updates android SDK to [15.6.3](https://github.com/intercom/intercom-android/releases/tag/15.6.3)