### PR TITLE
fix expo config plugin

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,1 +1,16 @@
-module.exports = require('./lib/commonjs/expo-plugins');
+const packageJson = require('./package.json');
+
+const pkg = {
+  // Prevent this plugin from being run more than once.
+  // This pattern enables users to safely migrate off of this
+  // out-of-tree `@config-plugins/intercom-react-native` to a future
+  // upstream plugin in `intercom-react-native`
+  name: packageJson.name,
+  // Indicates that this plugin is dangerously linked to a module,
+  // and might not work with the latest version of that module.
+  version: packageJson.version,
+};
+
+const plugin = require('./lib/commonjs/expo-plugins');
+
+module.exports = plugin.default(pkg);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "android",
     "ios",
     "cpp",
+    "app.plugin.js",
     "intercom-react-native.podspec",
     "!lib/typescript/example",
     "!android/build",

--- a/src/expo-plugins/index.ts
+++ b/src/expo-plugins/index.ts
@@ -16,7 +16,6 @@ import {
   insertContentsInsideObjcFunctionBlock,
 } from '@expo/config-plugins/build/ios/codeMod';
 import type { IntercomPluginProps, IntercomRegion } from './@types';
-import packageJson from '../../package.json';
 
 const mainApplication: ConfigPlugin<IntercomPluginProps> = (_config, props) =>
   withMainApplication(_config, (config) => {
@@ -122,19 +121,7 @@ const withIntercomReactNative: ConfigPlugin<IntercomPluginProps> = (
   return newConfig;
 };
 
-const pkg = {
-  // Prevent this plugin from being run more than once.
-  // This pattern enables users to safely migrate off of this
-  // out-of-tree `@config-plugins/intercom-react-native` to a future
-  // upstream plugin in `intercom-react-native`
-  name: packageJson.name,
-  // Indicates that this plugin is dangerously linked to a module,
-  // and might not work with the latest version of that module.
-  version: packageJson.version,
-};
+const configPlugin = (pkg: { name: string; version: string }) =>
+  createRunOncePlugin(withIntercomReactNative, pkg.name, pkg.version);
 
-export default createRunOncePlugin(
-  withIntercomReactNative,
-  pkg.name,
-  pkg.version
-);
+export default configPlugin;


### PR DESCRIPTION
But there is still an error:
```
Error: Cannot find module '../../package.json'
Require stack:
- /myproject/node_modules/@intercom/intercom-react-native/lib/commonjs/expo-plugins/index.js
```

since
https://github.com/intercom/intercom-react-native/blob/f75b38cdf9e4c43b8bb35fee98803920cf7518c0/src/expo-plugins/index.ts#L19
should be
```js
import packageJson from '../../../package.json';
```
because after the build the file ends up in /lib/commonjs/expo-plugins/index.js so it needs to step back three folders.
not sure how to fix that...