### PR TITLE
fix package.json types entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
When I installed the package the typescript definition ended up in:

node_modules/@intercom/intercom-react-native/lib/typescript/src/index.d.ts

not sure if this is the correct fix or of the build can instead put the types file in the typescript folder without the src folder.