### PR TITLE
fix: backwards compatibility with older AGPs

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.intercom.reactnative">
 
 </manifest>


### PR DESCRIPTION
As pointed out by @filipef101, I accidentally removed the namespace here.

Furthermore, this entire patch for newer AGPs (Including this PR, and #152) is actually not even needed anymore considering RN 0.73.3 (**Not 0.73.2/0.73.1 though**) adds backwards compatibility for packages to use `namespace`. *but*, it doesn't hurt to still have it!