### PR TITLE
Downgrade android sdk version to 15.4.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,5 +69,5 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '20.2.+')}"
-    implementation 'io.intercom.android:intercom-sdk:15.6.3'
+    implementation 'io.intercom.android:intercom-sdk:15.4.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# Why?
Our example app uses a library https://github.com/lugg/react-native-config which does not support Gradle 8.
The previous version does not impact our customers but just our example app.
We would need to find a replacement of this library and then update it again.