### PR TITLE
fix package.json types entry again

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
in 6.8.0 its no longer built into the src subfolder

<img width="384" alt="Screenshot 2024-03-05 at 22 06 24" src="https://github.com/intercom/intercom-react-native/assets/67104/ddad6823-759f-4c8c-a56b-1fa9e6fae9bf">
