### PR TITLE
Updated RN version to 6.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "6.8.0",
+  "version": "6.8.1",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# Why?
Fixed a typsecript import.
https://github.com/intercom/intercom-react-native/pull/171