### PR TITLE
fix: fix wrong setLogLevels log causing confusion

### DIFF
--- a/android/src/main/java/com/intercom/reactnative/IntercomModule.java
+++ b/android/src/main/java/com/intercom/reactnative/IntercomModule.java
@@ -228,7 +228,7 @@ public class IntercomModule extends ReactContextBaseJavaModule {
       Log.d(NAME, "setLogLevel");
       promise.resolve(true);
     } catch (Exception err) {
-      Log.e(NAME, "getUnreadConversationCount error:");
+      Log.e(NAME, "setLogLevel error:");
       Log.e(NAME, err.toString());
       promise.reject(IntercomErrorCodes.SET_LOG_LEVEL, err.toString());
     }


### PR DESCRIPTION
The method template was clearly copied from `getUnreadConversationCount` and someone forgot to update the log which is causing much confusion.