### PR TITLE
Update Node version in CI Engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ setup_env_file: &setup_env_file
 executors:
   default:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:22.2.0
     working_directory: ~/project
 
 orbs:


### PR DESCRIPTION
The current docker image for the CI uses Node 14. This PR updates it to the latest Node version.