### PR TITLE
Fix: messenger button opens the messenger instead of tickets space

### DIFF
--- a/sandboxes/IntercomExpo/App.js
+++ b/sandboxes/IntercomExpo/App.js
@@ -73,6 +73,7 @@ export default function App() {
     openCarousel,
     openSurvey,
     openMessageComposer,
+    openMessenger,
   } = useIntercom();
 
   return (
@@ -123,7 +124,7 @@ export default function App() {
 
               <TouchableOpacity
                 style={styles.button}
-                onPress={openTicketsSpace}
+                onPress={openMessenger}
               >
                 <Text style={styles.buttonText}>MESSENGER</Text>
               </TouchableOpacity>


### PR DESCRIPTION
The IntercomExpo sandbox demo has a small bug where the messenger button is opening the tickets space button.