### PR TITLE
Remove incorrect note from add event listener method

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -278,8 +278,6 @@ export type IntercomType = {
 
   /**
    * Add an `EventListener` to listen for `IntercomUnreadCountDidChange` events.
-   *
-   * @note This function is for Android only.
    */
   addEventListener: (
     event: EventType,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -277,7 +277,7 @@ export type IntercomType = {
   setLogLevel(logLevel: LogLevelType): Promise<boolean>;
 
   /**
-   * Add an `EventListener` to listen for `IntercomUnreadCountDidChange` events.
+   * Add an event listener for the supported event types.
    */
   addEventListener: (
     event: EventType,


### PR DESCRIPTION
The `addEventListener` documentation states that the method is only for Android, however this method is supported on iOS when using the `IntercomUnreadConversationCountDidChangeNotification` event ([docs in README here](https://github.com/intercom/intercom-react-native?tab=readme-ov-file#intercomaddeventlistenereventcallback)).

We've verified this locally, as such this PR removes this comment from the method documentation, and also updates the documentation to remove references to the outdated `IntercomUnreadCountDidChange` event type (which is not listed as a possible event type in the README)