### PR TITLE
[iOS] fix: prevent setDeviceToken to reject after resolving

### DIFF
--- a/ios/IntercomModule.m
+++ b/ios/IntercomModule.m
@@ -82,12 +82,18 @@ RCT_EXPORT_METHOD(sendTokenToIntercom:(NSString *)token
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     @try {
+        __block BOOL isSettled = NO;
         NSData *data = [self dataFromHexString:token];
         [Intercom setDeviceToken:data failure:^(NSError * _Nullable error) {
-            reject(SEND_TOKEN_TO_INTERCOM, @"Error in sendTokenToIntercom", error);
+            if (!isSettled) {
+                isSettled = YES;
+                reject(SEND_TOKEN_TO_INTERCOM, @"Error in sendTokenToIntercom", error);
+            }
         }];
-
-        resolve(@(YES));
+        if (!isSettled) {
+            isSettled = YES;
+            resolve(@(YES));
+        }
     } @catch (NSException *exception) {
         reject(SEND_TOKEN_TO_INTERCOM, @"Error in sendTokenToIntercom", [self exceptionToError:exception :SEND_TOKEN_TO_INTERCOM :@"sendTokenToIntercom"]);
     }


### PR DESCRIPTION
Hello!

Debugging why `setDeviceToken` is rejecting was a bit painful as the error ended up hidden by a `Tried to resolve a promise that has already been rejected` error.
I was a bit surprised about that, I would have expected `failure` to be async isn't it ?

I made those changes as an attempt to prevent both resolving and rejecting, but if failure is sync maybe just exiting in there would be enough?

Anyway, I guess adding a `success` callback to the iOS SDK `setDeviceToken` and resolving in there would be cleaner.

Thanks!