### PR TITLE
Release 8.2.0 

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
   - FBLazyVector (0.74.0)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - Intercom (18.2.2)
-  - intercom-react-native (8.1.0):
-    - Intercom (~> 18.2.0)
+  - Intercom (18.5.0)
+  - intercom-react-native (8.2.0):
+    - Intercom (~> 18.5.0)
     - React-Core
   - RCT-Folly (2024.01.01.00):
     - boost
@@ -1313,8 +1313,8 @@ SPEC CHECKSUMS:
   FBLazyVector: 026c8f4ae67b06e088ae01baa2271ef8a26c0e8c
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  Intercom: d39ed1b28ac6be4dd360cc3db17dd607595d2c9f
-  intercom-react-native: 2f0b89429e93befa1180dde37fc7d8916b762157
+  Intercom: d745ef2351c8c5d90c2c86756bdf32ca58059b23
+  intercom-react-native: 6cd32280f5bb1856674d8da7be47e297525e2f80
   RCT-Folly: 045d6ecaa59d826c5736dfba0b2f4083ff8d79df
   RCTDeprecation: 3ca8b6c36bfb302e1895b72cfe7db0de0c92cd47
   RCTRequired: 9fc183af555fd0c89a366c34c1ae70b7e03b1dc5
@@ -1368,4 +1368,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 15fb131f3e1a2b2d9a606515df1414680c8e67b5
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'IntercomFramework' => ['ios/assets/*'] }
 
   s.dependency "React-Core"
-  s.dependency "Intercom", '~> 18.2.0'
+  s.dependency "Intercom", '~> 18.5.0'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
- Updated iOS to use [18.5.0](https://github.com/intercom/intercom-ios/releases/tag/18.5.0) of the iOS SDK
- Updated Android to use [15.13.0](https://github.com/intercom/intercom-android/releases) of the Android SDK
- Increased Android min SDK version to 23
- Intercom SDK now targets Android 15 (API level 35)