### PR TITLE
feat: change appDelegate intercom import to support swift

### DIFF
--- a/src/expo-plugins/index.ts
+++ b/src/expo-plugins/index.ts
@@ -92,7 +92,8 @@ const withIntercomAndroid: ConfigPlugin<IntercomPluginProps> = (
 const appDelegate: ConfigPlugin<IntercomPluginProps> = (_config, props) =>
   withAppDelegate(_config, (config) => {
     let stringContents = config.modResults.contents;
-    stringContents = addObjcImports(stringContents, ['<IntercomModule.h>']);
+    const swiftAppDelegate = config.modResults.contents.includes('import React');
+    stringContents = swiftAppDelegate ? addImports(stringContents, ['Intercom'],false) : addObjcImports(stringContents, ['<IntercomModule.h>']);
 
     // Remove previous code
     stringContents = stringContents.replace(


### PR DESCRIPTION
Hi, With the release of expo 53 now appDelegate is using swift https://arc.net/l/quote/kngujiqn

so updating the import to fix the plugin for that