### PR TITLE
fix: fix typescript definition for `HelpCenterArticle`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,7 +71,7 @@ export type Company = {
 };
 
 export type HelpCenterArticle = {
-  it: string;
+  id: string;
   title: string;
 };
 export type HelpCenterSection = {


### PR DESCRIPTION
`HelpCenterArticle` has a field of `id`. I believe `it` is a typo