### PR TITLE
Update Android SDK to 17.0.0 and bump version to 8.7.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,5 +69,5 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '20.2.+')}"
-  implementation 'io.intercom.android:intercom-sdk:15.16.+'
+  implementation 'io.intercom.android:intercom-sdk:17.0.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "8.6.0",
+  "version": "8.7.0",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

This PR updates the Intercom Android SDK to version 17.0.0 and bumps the React Native wrapper version to 8.7.0.

## Changes

- **Updated Android SDK dependency** from `15.16.+` to `17.0.0` in `android/build.gradle`
- **Bumped package version** from `8.6.0` to `8.7.0` in `package.json`

## What's New in Android SDK 17.0.0

### 🚀 Enhancements
- **Added support for Dark Mode** (currently in beta, will be enabled for all customers in a future release)

## Release Notes

For the 8.7.0 release:
```
Release 8.7.0
- Updated Android to use [17.0.0](https://github.com/intercom/intercom-android/releases/tag/17.0.0) of the Android SDK
- Added support for Dark Mode on Android (currently in beta)
```

## Testing

- [ ] Run `npm test`
- [ ] Run `npm run typescript`
- [ ] Run `npm run lint`
- [ ] Test example app on Android
- [ ] Verify Dark Mode functionality (when enabled)

## Related Links

- [Android SDK 17.0.0 Release Notes](https://github.com/intercom/intercom-android/releases/tag/17.0.0)
- [Previous React Native Release 8.6.0](https://github.com/intercom/intercom-react-native/releases/tag/8.6.0)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author