### PR TITLE
Update Intercom SDKs for iOS and Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,5 +69,5 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '20.2.+')}"
-  implementation 'io.intercom.android:intercom-sdk:15.16.+'
+  implementation 'io.intercom.android:intercom-sdk:17.0.0'
 }

--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "Intercom", '~> 18.6.1'
+  s.dependency "Intercom", '~> 19.0.1'
 end


### PR DESCRIPTION
Closes: https://github.com/intercom/intercom/issues/413021

This pull request updates the Intercom SDKs for both iOS and Android to their latest versions. These updates are crucial for maintaining compatibility with the latest features and bug fixes provided by Intercom, ensuring our React Native integration remains up-to-date and fully functional.

Why we are making these changes:
Keeping our dependencies current is essential for security, performance, and feature parity. The new SDK versions introduce important improvements, such as bug fixes for iOS and Dark Mode support for Android. By implementing these updates, we ensure our application can leverage the latest capabilities offered by Intercom, providing a better experience for our users and maintaining the robustness of our integration.

What was changed and how:
1. iOS SDK: Updated from version 18.6.1 to 19.0.1 in `intercom-react-native.podspec`. This update includes critical bug fixes for crash issues related to media messages and gradient backgrounds.
2. Android SDK: Updated from version 15.16.+ to 17.0.0 in `android/build.gradle`. This major version update introduces Dark Mode support (beta) and requires compileSdk 35, which was already set in our project.

These changes were implemented by modifying the respective configuration files. The updates were then thoroughly tested to ensure compatibility and functionality. All Jest tests, TypeScript compilation, ESLint checks, and build processes completed successfully, confirming that the updates do not introduce any breaking changes or regressions in our codebase.