### PR TITLE
Update Intercom SDKs to latest versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,5 +69,5 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '20.2.+')}"
-  implementation 'io.intercom.android:intercom-sdk:17.0.0'
+  implementation 'io.intercom.android:intercom-sdk:17.0.3'
 }

--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "Intercom", '~> 18.7.3'
+  s.dependency "Intercom", '~> 19.1.0'
 end


### PR DESCRIPTION
Minimal update of Intercom SDKs to latest stable versions.

**Changes:**
- iOS SDK: `18.7.3` → `19.1.0`
- Android SDK: `17.0.0` → `17.0.3`

**Files changed:** 2 files, 2 lines
- `intercom-react-native.podspec` - iOS SDK version
- `android/build.gradle` - Android SDK version

No other dependencies or build tools modified to minimize risk of CI issues.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author