### PR TITLE
feat: use default launcher activity for notifications [android]

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,31 +173,61 @@ apply from: file("../../node_modules/@react-native-community/cli-platform-androi
 - Create `MainNotificationService.java` inside your app directory(`com.example.app`) with below content:
 
   ***Remember to replace `package com.example.app;`, with your app package name***
+  - Default Notification Behavior (Goes back to the parent default launcher activity when the user taps the notification):
 
-```java
-package com.example.app;
+    ```java
+    package com.example.app;
 
-import com.google.firebase.messaging.FirebaseMessagingService;
-import com.google.firebase.messaging.RemoteMessage;
-import com.intercom.reactnative.IntercomModule;
+    import com.google.firebase.messaging.FirebaseMessagingService;
+    import com.google.firebase.messaging.RemoteMessage;
+    import com.intercom.reactnative.IntercomModule;
 
-public class MainNotificationService extends FirebaseMessagingService {
+    public class MainNotificationService extends FirebaseMessagingService {
 
-  @Override
-  public void onNewToken(String refreshedToken) {
-    IntercomModule.sendTokenToIntercom(getApplication(), refreshedToken);
-    //DO LOGIC HERE
-  }
+      @Override
+      public void onNewToken(String refreshedToken) {
+        IntercomModule.sendTokenToIntercom(getApplication(), refreshedToken);
+        //DO LOGIC HERE
+      }
 
-  public void onMessageReceived(RemoteMessage remoteMessage) {
-    if (IntercomModule.isIntercomPush(remoteMessage)) {
-      IntercomModule.handleRemotePushMessage(getApplication(), remoteMessage);
-    } else {
-      // HANDLE NON-INTERCOM MESSAGE
+      public void onMessageReceived(RemoteMessage remoteMessage) {
+        if (IntercomModule.isIntercomPush(remoteMessage)) {
+          IntercomModule.handleRemotePushMessage(getApplication(), remoteMessage);
+        } else {
+          // HANDLE NON-INTERCOM MESSAGE
+        }
+      }
     }
-  }
-}
-```
+    ```
+
+  - Custom Stack:
+
+    ```java
+    package com.example.app;
+
+    import com.google.firebase.messaging.FirebaseMessagingService;
+    import com.google.firebase.messaging.RemoteMessage;
+    import com.intercom.reactnative.IntercomModule;
+
+    public class MainNotificationService extends FirebaseMessagingService {
+
+      @Override
+      public void onNewToken(String refreshedToken) {
+        IntercomModule.sendTokenToIntercom(getApplication(), refreshedToken);
+        //DO LOGIC HERE
+      }
+
+      public void onMessageReceived(RemoteMessage remoteMessage) {
+        if (IntercomModule.isIntercomPush(remoteMessage)) {
+          TaskStackBuilder customStack = TaskStackBuilder.create(getApplication());
+          customStack.addNextIntent(new Intent(getApplication(), MainActivity.class)); // Replace with your custom activity
+          IntercomModule.handleRemotePushWithCustomStack(getApplication(), remoteMessage, customStack);
+        } else {
+          // HANDLE NON-INTERCOM MESSAGE
+        }
+      }
+    }
+    ```
 
 - Edit `AndroidManifest.xml`. Add below content inside `<application>` below `<activity/>`
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,5 +69,5 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '20.2.+')}"
-  implementation 'io.intercom.android:intercom-sdk:17.0.3'
+  implementation 'io.intercom.android:intercom-sdk:17.1.0'
 }

--- a/android/src/main/java/com/intercom/reactnative/IntercomModule.java
+++ b/android/src/main/java/com/intercom/reactnative/IntercomModule.java
@@ -2,6 +2,7 @@ package com.intercom.reactnative;
 
 import android.app.Activity;
 import android.app.Application;
+import android.content.Intent;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -37,6 +38,7 @@ import io.intercom.android.sdk.helpcenter.collections.HelpCenterCollection;
 import io.intercom.android.sdk.helpcenter.sections.HelpCenterCollectionContent;
 import io.intercom.android.sdk.identity.Registration;
 import io.intercom.android.sdk.push.IntercomPushClient;
+import android.app.TaskStackBuilder;
 
 @ReactModule(name = IntercomModule.NAME)
 public class IntercomModule extends ReactContextBaseJavaModule {
@@ -65,11 +67,25 @@ public class IntercomModule extends ReactContextBaseJavaModule {
     }
   }
 
-  public static void handleRemotePushMessage(@NonNull Application application, RemoteMessage
-    remoteMessage) {
+  public static void handleRemotePushWithCustomStack(@NonNull Application application, RemoteMessage remoteMessage,
+      TaskStackBuilder customStack) {
     try {
-      Map message = remoteMessage.getData();
-      intercomPushClient.handlePush(application, message);
+      Map<String, String> message = remoteMessage.getData();
+      intercomPushClient.handlePushWithCustomStack(application, message, customStack);
+    } catch (Exception err) {
+      Log.e(NAME, "handlePushWithCustomStack error:");
+      Log.e(NAME, err.toString());
+    }
+  }
+
+  public static void handleRemotePushMessage(@NonNull Application application, RemoteMessage remoteMessage) {
+    try {
+      TaskStackBuilder customStack = TaskStackBuilder.create(application);
+      Intent launchIntent = application.getPackageManager().getLaunchIntentForPackage(application.getPackageName());
+      if (launchIntent != null) {
+        customStack.addNextIntent(launchIntent);
+      }
+      handleRemotePushWithCustomStack(application, remoteMessage, customStack);
     } catch (Exception err) {
       Log.e(NAME, "handleRemotePushMessage error:");
       Log.e(NAME, err.toString());
@@ -107,8 +123,7 @@ public class IntercomModule extends ReactContextBaseJavaModule {
         Log.e(NAME, "no current activity");
       }
 
-    } catch (
-      Exception err) {
+    } catch (Exception err) {
       Log.e(NAME, "sendTokenToIntercom error:");
       Log.e(NAME, err.toString());
       promise.reject(IntercomErrorCodes.SEND_TOKEN_TO_INTERCOM, err.toString());
@@ -117,24 +132,25 @@ public class IntercomModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void loginUnidentifiedUser(Promise promise) {
-      Intercom.client().loginUnidentifiedUser(new IntercomStatusCallback() {
-        @Override
-        public void onSuccess() {
-          promise.resolve(true);
-        }
+    Intercom.client().loginUnidentifiedUser(new IntercomStatusCallback() {
+      @Override
+      public void onSuccess() {
+        promise.resolve(true);
+      }
 
-        @Override
-        public void onFailure(@NonNull IntercomError intercomError) {
-          Log.e("ERROR", intercomError.getErrorMessage());
-          promise.reject(String.valueOf(intercomError.getErrorCode()), intercomError.getErrorMessage());
-        }
-      });
+      @Override
+      public void onFailure(@NonNull IntercomError intercomError) {
+        Log.e("ERROR", intercomError.getErrorMessage());
+        promise.reject(String.valueOf(intercomError.getErrorCode()), intercomError.getErrorMessage());
+      }
+    });
   }
 
   @ReactMethod
   public void loginUserWithUserAttributes(ReadableMap params, Promise promise) {
     Boolean hasEmail = params.hasKey("email") && IntercomHelpers.getValueAsStringForKey(params, "email").length() > 0;
-    Boolean hasUserId = params.hasKey("userId") && IntercomHelpers.getValueAsStringForKey(params, "userId").length() > 0;
+    Boolean hasUserId = params.hasKey("userId")
+        && IntercomHelpers.getValueAsStringForKey(params, "userId").length() > 0;
     Registration registration = null;
     if (hasEmail && hasUserId) {
       String email = IntercomHelpers.getValueAsStringForKey(params, "email");
@@ -181,19 +197,19 @@ public class IntercomModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void updateUser(ReadableMap params, Promise promise) {
-      UserAttributes userAttributes = IntercomHelpers.buildUserAttributes(params);
-      Intercom.client().updateUser(userAttributes, new IntercomStatusCallback() {
-        @Override
-        public void onSuccess() {
-          promise.resolve(true);
-        }
+    UserAttributes userAttributes = IntercomHelpers.buildUserAttributes(params);
+    Intercom.client().updateUser(userAttributes, new IntercomStatusCallback() {
+      @Override
+      public void onSuccess() {
+        promise.resolve(true);
+      }
 
-        @Override
-        public void onFailure(@NonNull IntercomError intercomError) {
-          Log.e("ERROR", intercomError.getErrorMessage());
-          promise.reject(String.valueOf(intercomError.getErrorCode()), intercomError.getErrorMessage());
-        }
-      });
+      @Override
+      public void onFailure(@NonNull IntercomError intercomError) {
+        Log.e("ERROR", intercomError.getErrorMessage());
+        promise.reject(String.valueOf(intercomError.getErrorCode()), intercomError.getErrorMessage());
+      }
+    });
   }
 
   @ReactMethod
@@ -358,7 +374,6 @@ public class IntercomModule extends ReactContextBaseJavaModule {
     }
   }
 
-
   @ReactMethod
   public void fetchHelpCenterCollections(Promise promise) {
     try {
@@ -400,7 +415,8 @@ public class IntercomModule extends ReactContextBaseJavaModule {
         CollectionContentRequestCallback collectionContentCallback = new CollectionContentRequestCallback() {
           @Override
           public void onComplete(@NotNull HelpCenterCollectionContent helpCenterCollectionContent) {
-            promise.resolve(IntercomHelpCenterHelpers.parseHelpCenterCollectionsContentToReadableMap(helpCenterCollectionContent));
+            promise.resolve(
+                IntercomHelpCenterHelpers.parseHelpCenterCollectionsContentToReadableMap(helpCenterCollectionContent));
           }
 
           @Override
@@ -435,7 +451,8 @@ public class IntercomModule extends ReactContextBaseJavaModule {
         SearchRequestCallback collectionContentCallback = new SearchRequestCallback() {
           @Override
           public void onComplete(@NotNull List<HelpCenterArticleSearchResult> helpCenterArticleSearchResult) {
-            promise.resolve(IntercomHelpCenterHelpers.parseHelpCenterArticleSearchToReadableArray(helpCenterArticleSearchResult));
+            promise.resolve(
+                IntercomHelpCenterHelpers.parseHelpCenterArticleSearchToReadableArray(helpCenterArticleSearchResult));
           }
 
           @Override


### PR DESCRIPTION
## Changes
- Update `handleRemotePushMessage` to use default launcher activity when user goes back. This functionality was [recently removed from native SDK](https://github.com/intercom/intercom-android/releases/tag/16.2.0) causing all react native apps to close automatically when the user goes back.
- Introduces new `handleRemotePushWithCustomStack` Android Api. Users can use this to create a custom activity backstack if they wish to not use the default behaviour.
- Bumps Android SDK version from `17.0.3` to `17.1.0`