### PR TITLE
fix: resolve React Native codegen compatibility issues

### DIFF
--- a/ios/IntercomModule.h
+++ b/ios/IntercomModule.h
@@ -1,7 +1,7 @@
 #import <React/RCTBridgeModule.h>
 
 #ifdef RCT_NEW_ARCH_ENABLED
-#import "IntercomReactNativeSpec.h"
+#import <IntercomReactNativeSpec/IntercomReactNativeSpec.h>
 @interface IntercomModule : NSObject <NativeIntercomSpecSpec>
 #else
 @interface IntercomModule : NSObject <RCTBridgeModule>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/NativeIntercomSpec.ts
+++ b/src/NativeIntercomSpec.ts
@@ -4,13 +4,13 @@ import { TurboModuleRegistry } from 'react-native';
 export interface UserAttributes {
   companies?: Array<{
     createdAt?: number;
-    customAttributes?: { [key: string]: boolean | string | number };
+    customAttributes?: Object; // { [key: string]: boolean | string | number };
     id: string;
     monthlySpend?: number;
     name?: string;
     plan?: string;
   }>;
-  customAttributes?: { [key: string]: boolean | string | number };
+  customAttributes?: Object; // { [key: string]: boolean | string | number };
   email?: string;
   languageOverride?: string;
   name?: string;
@@ -21,12 +21,7 @@ export interface UserAttributes {
 }
 
 interface TurboModuleContent {
-  type:
-    | 'ARTICLE'
-    | 'CAROUSEL'
-    | 'SURVEY'
-    | 'HELP_CENTER_COLLECTIONS'
-    | 'CONVERSATION';
+  type: string; // ARTICLE, CAROUSEL, SURVEY, HELP_CENTER_COLLECTIONS, CONVERSATION
   id?: string;
   ids?: Array<string>;
 }


### PR DESCRIPTION
- Replace union types with Object to fix "union types are unsupported in structs" error
- Update IntercomReactNativeSpec.h import path for New Architecture