### PR TITLE
Remove yarn >=3 version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,8 +180,7 @@
   },
   "packageManager": "yarn@3.6.1",
   "engines": {
-    "node": ">=18",
-    "yarn": ">=3"
+    "node": ">=18"
   },
   "codegenConfig": {
     "name": "IntercomReactNativeSpec",


### PR DESCRIPTION
This removes the requirement for yarn version 3 or higher, which was
breaking user setups when they use this SDK with older yarn versions.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>