### PR TITLE
feat(android)!: upgrade Intercom Android SDK to 18.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,16 +111,16 @@ public void onCreate() {
 }
 ```
 
-- Open `android/build.gradle` and change `minSdkVersion` to **23**, `compileSdkVersion` and `targetSdkVersion` to **35**
+- Open `android/build.gradle` and change `minSdkVersion` to **23**, `compileSdkVersion` and `targetSdkVersion` to **36**
 
 ```Gradle
 buildscript {
     // ...
     ext {
-        buildToolsVersion = "35.0.0"
+        buildToolsVersion = "36.0.0"
         minSdkVersion = 23 // <-- Here
-        compileSdkVersion = 35 // <-- Here
-        targetSdkVersion = 35 // <-- Here
+        compileSdkVersion = 36 // <-- Here
+        targetSdkVersion = 36 // <-- Here
     }
     // ...
 }
@@ -273,22 +273,6 @@ apply from: file("../../node_modules/@react-native-community/cli-platform-androi
 
   </application>
 </manifest>
-```
-
-- Add below code to your React Native app
-
-```jsx
-useEffect(() => {
-  /**
-   * Handle PushNotification
-   */
-  const appStateListener = AppState.addEventListener(
-    'change',
-    (nextAppState) => nextAppState === 'active' && Intercom.handlePushMessage()
-  );
-  return () => AppState.removeEventListener('change', () => true); // <- for RN < 0.65
-  return () => appStateListener.remove(); // <- for RN >= 0.65
-}, []);
 ```
 
 #### Android: Push notification deep links support
@@ -993,31 +977,6 @@ Gets the number of unread conversations for a user.
 ### Returns
 
 `Promise<number>`
-
----
-
-### `Intercom.handlePushMessage()`
-
-Handles the opening of an Intercom push message. This will retrieve the URI from the last Intercom push message.
-
-```javascript
-useEffect(() => {
-  /**
-   * Handle PushNotification Open
-   */
-  const appStateListener = AppState.addEventListener(
-    'change',
-    (nextAppState) => nextAppState === 'active' && Intercom.handlePushMessage()
-  );
-
-  return () => AppState.removeEventListener('change', () => {}); // <- for RN < 0.65
-  return () => appStateListener.remove(); // <- for RN >= 0.65
-}, []);
-```
-
-### Returns
-
-`Promise<boolean>`
 
 ---
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,6 +84,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:24.1.2"
-  implementation 'io.intercom.android:intercom-sdk:18.0.0'
-  implementation 'io.intercom.android:intercom-sdk-ui:18.0.0'
+  implementation 'io.intercom.android:intercom-sdk:18.0.1'
+  implementation 'io.intercom.android:intercom-sdk-ui:18.0.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,10 +5,10 @@ def packageVersion = '"' + packageJson.version + '"'
 
 buildscript {
   ext {
-    buildToolsVersion = "35.0.0"
+    buildToolsVersion = "36.0.0"
     minSdkVersion = 23
-    compileSdkVersion = 35
-    targetSdkVersion = 35
+    compileSdkVersion = 36
+    targetSdkVersion = 36
     ndkVersion = "26.1.10909125"
     kotlinVersion = "1.9.22"
   }
@@ -19,7 +19,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.6.1")
+      classpath("com.android.tools.build:gradle:8.9.0")
       classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
     }
   }
@@ -53,7 +53,7 @@ android {
       minifyEnabled false
     }
   }
-  lintOptions {
+  lint {
     disable 'GradleCompatible'
   }
   buildFeatures {
@@ -84,6 +84,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:24.1.2"
-  implementation 'io.intercom.android:intercom-sdk:17.4.7'
-  implementation 'io.intercom.android:intercom-sdk-ui:17.4.7'
+  implementation 'io.intercom.android:intercom-sdk:18.0.0'
+  implementation 'io.intercom.android:intercom-sdk-ui:18.0.0'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/src/main/java/com/intercom/reactnative/IntercomErrorCodes.java
+++ b/android/src/main/java/com/intercom/reactnative/IntercomErrorCodes.java
@@ -20,7 +20,6 @@ public class IntercomErrorCodes {
   public static final String SET_LAUNCHER_VISIBILITY = "208";
   public static final String SET_BOTTOM_PADDING = "209";
   public static final String SET_THEME_MODE = "210";
-  public static final String HANDLE_PUSH_MESSAGE = "301";
   public static final String SEND_TOKEN_TO_INTERCOM = "302";
   public static final String FETCH_HELP_CENTER_COLLECTIONS = "901";
   public static final String FETCH_HELP_CENTER_COLLECTION = "902";

--- a/android/src/newarch/IntercomModule.java
+++ b/android/src/newarch/IntercomModule.java
@@ -4,8 +4,6 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
 import android.util.Log;
-import android.widget.Toast;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -13,7 +11,6 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.module.annotations.ReactModule;
 import com.google.firebase.messaging.RemoteMessage;
@@ -112,19 +109,6 @@ public class IntercomModule extends NativeIntercomSpecSpec {
     } catch (Exception err) {
       Log.e(NAME, "sendTokenToIntercom error:");
       Log.e(NAME, err.toString());
-    }
-  }
-
-  @ReactMethod
-  public void handlePushMessage(Promise promise) {
-    try {
-      Intercom.client().handlePushMessage();
-      promise.resolve(true);
-      Log.d(NAME, "handlePushMessage");
-    } catch (Exception err) {
-      Log.e(NAME, "handlePushMessage error:");
-      Log.e(NAME, err.toString());
-      promise.reject(IntercomErrorCodes.HANDLE_PUSH_MESSAGE, err.toString());
     }
   }
 

--- a/android/src/oldarch/IntercomModule.java
+++ b/android/src/oldarch/IntercomModule.java
@@ -4,8 +4,6 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
 import android.util.Log;
-import android.widget.Toast;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -13,7 +11,6 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.module.annotations.ReactModule;
 import com.google.firebase.messaging.RemoteMessage;
@@ -96,19 +93,6 @@ public class IntercomModule extends ReactContextBaseJavaModule {
   public static void sendTokenToIntercom(Application application, @NonNull String token) {
     intercomPushClient.sendTokenToIntercom(application, token);
     Log.d(NAME, "sendTokenToIntercom");
-  }
-
-  @ReactMethod
-  public void handlePushMessage(Promise promise) {
-    try {
-      Intercom.client().handlePushMessage();
-      promise.resolve(true);
-      Log.d(NAME, "handlePushMessage");
-    } catch (Exception err) {
-      Log.e(NAME, "handlePushMessage error:");
-      Log.e(NAME, err.toString());
-      promise.reject(IntercomErrorCodes.HANDLE_PUSH_MESSAGE, err.toString());
-    }
   }
 
   @ReactMethod

--- a/examples/example/src/App.tsx
+++ b/examples/example/src/App.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import {
   Alert,
-  AppState,
   Image,
   Linking,
   NativeEventEmitter,
@@ -134,12 +133,6 @@ export default function App() {
     /**
      * Handle PushNotification
      */
-    const appChangeListener = AppState.addEventListener(
-      'change',
-      (nextAppState) =>
-        nextAppState === 'active' && Intercom.handlePushMessage()
-    );
-
     /**
      * Handle Push Notification deep links
      */
@@ -184,10 +177,6 @@ export default function App() {
       // @ts-ignore - type definitions haven't been updated to 0.65 yet
       urlListener.remove(); // <- for RN 0.65+
       // Linking.removeEventListener('url', () => {}); <- for RN < 0.65
-
-      // @ts-ignore - type definitions haven't been updated to 0.65 yet
-      appChangeListener.remove(); // <- for RN 0.65+
-      //AppState.removeEventListener('change', () => {}); <- for RN < 0.65
     };
   }, []);
 

--- a/examples/example/src/App.tsx
+++ b/examples/example/src/App.tsx
@@ -131,9 +131,6 @@ export default function App() {
     });
 
     /**
-     * Handle PushNotification
-     */
-    /**
      * Handle Push Notification deep links
      */
     const urlListener = Linking.addEventListener('url', (event) => {

--- a/examples/expo-example/app/_layout.tsx
+++ b/examples/expo-example/app/_layout.tsx
@@ -4,10 +4,8 @@ import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import React, { useEffect } from 'react';
-import { Alert, AppState, Linking } from 'react-native';
+import { Alert, Linking } from 'react-native';
 import 'react-native-reanimated';
-
-import Intercom from '@intercom/intercom-react-native';
 
 export default function RootLayout() {
   const [loaded] = useFonts({
@@ -15,12 +13,6 @@ export default function RootLayout() {
   });
 
   useEffect(() => {
-    // Handle push notifications when app is active
-    const subscription = AppState.addEventListener(
-      'change',
-      (nextStatus) => nextStatus === 'active' && Intercom.handlePushMessage()
-    );
-
     // Handle deep links
     const urlListener = Linking.addEventListener('url', (event) => {
       if (event) {
@@ -29,7 +21,6 @@ export default function RootLayout() {
     });
 
     return () => {
-      subscription.remove();
       urlListener.remove();
     };
   }, []);

--- a/examples/with-notifications/src/screens/HomeScreen.tsx
+++ b/examples/with-notifications/src/screens/HomeScreen.tsx
@@ -1,10 +1,5 @@
 import React, { useEffect } from 'react';
-import {
-  Text,
-  TextInput,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { Text, TextInput, TouchableOpacity, View } from 'react-native';
 import Intercom, { Visibility } from '@intercom/intercom-react-native';
 import { requestNotifications } from 'react-native-permissions';
 import { useIntercom } from '../hooks/useIntercom';

--- a/examples/with-notifications/src/screens/HomeScreen.tsx
+++ b/examples/with-notifications/src/screens/HomeScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import {
-  AppState,
   Text,
   TextInput,
   TouchableOpacity,
@@ -12,14 +11,6 @@ import { useIntercom } from '../hooks/useIntercom';
 import { styles } from '../styles/App.styles';
 
 export function HomeScreen(): React.JSX.Element {
-  useEffect(() => {
-    const subscription = AppState.addEventListener(
-      'change',
-      nextStatus => nextStatus === 'active' && Intercom?.handlePushMessage()
-    );
-    return subscription.remove;
-  }, []);
-
   useEffect(() => {
     (async () => {
       // Request permissions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "9.8.0",
+  "version": "10.0.0",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/NativeIntercomSpec.ts
+++ b/src/NativeIntercomSpec.ts
@@ -80,7 +80,6 @@ export interface Spec extends TurboModule {
   setInAppMessageVisibility(visibility: string): Promise<boolean>;
   setLauncherVisibility(visibility: string): Promise<boolean>;
   setNeedsStatusBarAppearanceUpdate(): Promise<boolean>;
-  handlePushMessage(): Promise<boolean>;
   sendTokenToIntercom(token: string): Promise<boolean>;
   setLogLevel(logLevel: string): Promise<boolean>;
   setThemeMode(themeMode: string): Promise<boolean>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -252,13 +252,6 @@ export type IntercomType = {
   setNeedsStatusBarAppearanceUpdate(): Promise<boolean>;
 
   /**
-   * Handle an Android push notification payload sent by Intercom.
-   *
-   * @note Android only. iOS handles push notifications automatically.
-   */
-  handlePushMessage(): Promise<boolean>;
-
-  /**
    * Send a device token to Intercom to enable push notifications to be sent to the User.
    * @param token The device token to send to the server.
    */
@@ -401,11 +394,6 @@ const Intercom: IntercomType = {
 
   setNeedsStatusBarAppearanceUpdate: Platform.select({
     ios: IntercomModule.setNeedsStatusBarAppearanceUpdate,
-    default: async () => true,
-  }),
-
-  handlePushMessage: Platform.select({
-    android: IntercomModule.handlePushMessage,
     default: async () => true,
   }),
 


### PR DESCRIPTION
### Why?

Android SDK 18.0.1 is a major release that removes the `handlePushMessage()` API (the SDK now auto-opens conversations on push tap), raises compileSdk/targetSdk to 36, and migrates internal storage from SharedPreferences to DataStore. The React Native wrapper needs to be updated to align with these breaking changes.

- https://github.com/intercom/intercom-android/releases/tag/18.0.0

### How?

Remove the `handlePushMessage()` method from native modules, TurboModule spec, and public JS API. Bump build tooling (AGP 8.9.0, Gradle 8.11.1, compileSdk/targetSdk 36) to match SDK requirements. Clean up dead code left behind by the removal.

<details>
<summary>Implementation Plan</summary>

## Evaluation of Changes

| Change | File(s) | Verdict |
|--------|---------|---------|
| SDK bumped to 18.0.1 (`intercom-sdk` + `intercom-sdk-ui`) | `android/build.gradle` | ✅ Correct |
| compileSdk/targetSdk → 36, buildTools → 36.0.0 | `android/build.gradle` | ✅ Correct |
| AGP 8.6.1 → 8.9.0 | `android/build.gradle` | ✅ Correct (AGP 8.9 requires Gradle 8.11+) |
| Gradle 8.7 → 8.11.1 | `gradle-wrapper.properties` | ✅ Correct (compatible with AGP 8.9) |
| `handlePushMessage()` removed from newarch module | `newarch/IntercomModule.java` | ✅ Correct |
| `handlePushMessage()` removed from oldarch module | `oldarch/IntercomModule.java` | ✅ Correct |
| `handlePushMessage()` removed from TurboModule spec | `src/NativeIntercomSpec.ts` | ✅ Correct |
| `handlePushMessage` removed from public API + type | `src/index.tsx` | ✅ Correct |
| Example apps upgraded (RN 0.74 → 0.81) | `examples/` | ✅ Correct (no `handlePushMessage` refs remain) |

The static helper methods (`handleRemotePushWithCustomStack`, `handleRemotePushMessage`) correctly use `intercomPushClient.handlePushWithCustomStack()` — the replacement API that's been stable since SDK 16.2.0. All other `Intercom.client().*` calls in the wrapper remain unchanged in 18.0.1.

## Cleanup

- Remove dead `HANDLE_PUSH_MESSAGE` error code constant
- Remove unused `Toast` and `ReadableArray` imports from both arch modules
- Migrate deprecated `lintOptions` to `lint` block in build.gradle
- Update README to remove `handlePushMessage` docs and fix SDK version numbers
- Remove `handlePushMessage` AppState listeners from all example apps

## Considerations for release

- **Semver**: Removing `handlePushMessage` from the public JS API is a breaking change — warrants a major version bump
- **Data migration**: Upgrading triggers a one-way migration (SharedPreferences → DataStore). Downgrading back to 17.x will lose local SDK state.

## Verification

- Android project builds successfully (`assembleDebug`)
- Example app launches on emulator without crashes
- Intercom SDK initializes correctly (shows logged-in status and unread count)
- No remaining `handlePushMessage` references in codebase

</details>

<sub>Generated with Claude Code</sub>