### PR TITLE
fix(android): use ReactApplicationContext instead of getCurrentActivity

### DIFF
--- a/android/src/newarch/IntercomModule.java
+++ b/android/src/newarch/IntercomModule.java
@@ -120,17 +120,10 @@ public class IntercomModule extends NativeIntercomSpecSpec {
         promise.reject(IntercomErrorCodes.SEND_TOKEN_TO_INTERCOM, "token is null or empty");
         return;
       }
-      Activity activity = getCurrentActivity();
-      if (activity != null && activity.getApplication() != null) {
-        intercomPushClient.sendTokenToIntercom(activity.getApplication(), token);
-        Log.d(NAME, "sendTokenToIntercom");
-        promise.resolve(true);
-      } else {
-        Log.e(NAME, "sendTokenToIntercom");
-        Log.e(NAME, "no current activity");
-        promise.reject(IntercomErrorCodes.SEND_TOKEN_TO_INTERCOM, "no current activity");
-      }
-
+      Application application = (Application) getReactApplicationContext().getApplicationContext();
+      intercomPushClient.sendTokenToIntercom(application, token);
+      Log.d(NAME, "sendTokenToIntercom");
+      promise.resolve(true);
     } catch (Exception err) {
       Log.e(NAME, "sendTokenToIntercom error:");
       Log.e(NAME, err.toString());
@@ -616,13 +609,9 @@ public class IntercomModule extends NativeIntercomSpecSpec {
   @ReactMethod
   public void initialize(String apiKey, String appId, Promise promise) {
     try {
-      Activity activity = getCurrentActivity();
-      if (activity != null && activity.getApplication() != null) {
-        IntercomModule.initialize(activity.getApplication(), apiKey, appId);
-        promise.resolve(true);
-      } else {
-        promise.reject(IntercomErrorCodes.INITIALIZE_ERROR, "Activity is null");
-      }
+      Application application = (Application) getReactApplicationContext().getApplicationContext();
+      IntercomModule.initialize(application, apiKey, appId);
+      promise.resolve(true);
     } catch (Exception err) {
       Log.e(NAME, "initialize error:");
       Log.e(NAME, err.toString());

--- a/android/src/oldarch/IntercomModule.java
+++ b/android/src/oldarch/IntercomModule.java
@@ -98,16 +98,10 @@ public class IntercomModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void sendTokenToIntercom(@NonNull String token, Promise promise) {
     try {
-      Activity activity = getCurrentActivity();
-      if (activity != null) {
-        intercomPushClient.sendTokenToIntercom(activity.getApplication(), token);
-        Log.d(NAME, "sendTokenToIntercom");
-        promise.resolve(true);
-      } else {
-        Log.e(NAME, "sendTokenToIntercom");
-        Log.e(NAME, "no current activity");
-      }
-
+      Application application = (Application) getReactApplicationContext().getApplicationContext();
+      intercomPushClient.sendTokenToIntercom(application, token);
+      Log.d(NAME, "sendTokenToIntercom");
+      promise.resolve(true);
     } catch (Exception err) {
       Log.e(NAME, "sendTokenToIntercom error:");
       Log.e(NAME, err.toString());
@@ -593,13 +587,9 @@ public class IntercomModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void initialize(String apiKey, String appId, Promise promise) {
     try {
-      Activity activity = getCurrentActivity();
-      if (activity != null && activity.getApplication() != null) {
-        IntercomModule.initialize(activity.getApplication(), apiKey, appId);
-        promise.resolve(true);
-      } else {
-        promise.reject(IntercomErrorCodes.INITIALIZE_ERROR, "Activity is null");
-      }
+      Application application = (Application) getReactApplicationContext().getApplicationContext();
+      IntercomModule.initialize(application, apiKey, appId);
+      promise.resolve(true);
     } catch (Exception err) {
       Log.e(NAME, "initialize error:");
       Log.e(NAME, err.toString());


### PR DESCRIPTION
### Why?

On Android, `initialize()` and `sendTokenToIntercom()` used `getCurrentActivity()` to obtain an `Application` reference. `getCurrentActivity()` can return `null` when JavaScript execution starts before the Android Activity is fully attached — a known React Native lifecycle timing gap — causing intermittent promise rejections with `"Activity is null"`.

### How?

Replace `getCurrentActivity().getApplication()` with `(Application) getReactApplicationContext().getApplicationContext()` in both methods across oldarch and newarch `IntercomModule`. `ReactApplicationContext` is always available when a `@ReactMethod` is invoked, making this reliable regardless of Activity lifecycle state.

<sub>Generated with Claude Code</sub>