### PR TITLE
fix(ci): harden labeler workflow against supply chain attacks

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: 'Pull Request Labeler'
 on:
-  - pull_request_target
+  - pull_request_target  # Required: labeler needs write access to add labels on fork PRs
 
 jobs:
   labeler:
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0


### PR DESCRIPTION
### Why?

The labeler workflow used a mutable tag reference (`actions/labeler@v5`) which is vulnerable to supply chain attacks — a compromised upstream repo can silently redirect a tag to malicious code. The `pull_request_target` trigger also lacked the required justification comment.

### How?

SHA-pin the action reference to an immutable commit hash and document why `pull_request_target` is necessary (the labeler needs write access to label fork PRs).

<details>
<summary>Implementation Plan</summary>

**Rule 3 — SHA-pin action reference:**
- `actions/labeler@v5` → `actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9` (v5.0.0)

**Rule 8 — Document `pull_request_target` justification:**
- Added inline comment explaining the trigger is required for write access on fork PRs

</details>

<sub>Generated with Claude Code</sub>