### PR TITLE
chore: update Intercom SDK dependencies (iOS: 19.5.7 → 19.6.0, Android: 18.0.2 → 18.1.0)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,6 +84,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:24.1.2"
-  implementation 'io.intercom.android:intercom-sdk:18.0.2'
-  implementation 'io.intercom.android:intercom-sdk-ui:18.0.2'
+  implementation 'io.intercom.android:intercom-sdk:18.1.0'
+  implementation 'io.intercom.android:intercom-sdk-ui:18.1.0'
 }

--- a/examples/example/ios/Podfile.lock
+++ b/examples/example/ios/Podfile.lock
@@ -8,15 +8,15 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - Intercom (19.5.7)
-  - intercom-react-native (10.0.1):
+  - Intercom (19.6.0)
+  - intercom-react-native (10.1.0):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - Intercom (~> 19.5.7)
+    - Intercom (~> 19.6.0)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2560,8 +2560,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  Intercom: 74d4318a7275fa6f6a1466443f2af10ebd679d57
-  intercom-react-native: a5403a324935f1fea209844719badd991e3f30ef
+  Intercom: 53754c4fa69a687cf72d8836a3f2227d218585f2
+  intercom-react-native: 060f6bf80a03978015915c4e5882a5e87b225297
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a

--- a/examples/with-notifications/ios/Podfile.lock
+++ b/examples/with-notifications/ios/Podfile.lock
@@ -8,15 +8,15 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - Intercom (19.5.7)
-  - intercom-react-native (10.0.1):
+  - Intercom (19.6.0)
+  - intercom-react-native (10.1.0):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - Intercom (~> 19.5.7)
+    - Intercom (~> 19.6.0)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2773,8 +2773,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  Intercom: 74d4318a7275fa6f6a1466443f2af10ebd679d57
-  intercom-react-native: a5403a324935f1fea209844719badd991e3f30ef
+  Intercom: 53754c4fa69a687cf72d8836a3f2227d218585f2
+  intercom-react-native: 060f6bf80a03978015915c4e5882a5e87b225297
   MMKV: 7b5df6a8bf785c6705cc490c541b9d8a957c4a64
   MMKVCore: 3f40b896e9ab522452df9df3ce983471aa2449ba
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f

--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
-  s.dependency "Intercom", '~> 19.5.7'
+  s.dependency "Intercom", '~> 19.6.0'
 
   is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
   folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "10.0.1",
+  "version": "10.1.0",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
- Updated iOS SDK from 19.5.7 to 19.6.0
- Updated Android SDK from 18.0.2 to 18.1.0
- Bumped version from 10.0.1 to 10.1.0 (minor)
- Updated lockfiles and example projects