### PR TITLE
Route npm installs through Socket Firewall registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,12 @@ jobs:
           node-version: 22.14.0
 
       - run:
+          name: Verify Socket Firewall registry is active
+          command: |
+            REGISTRY=$(npm config get registry)
+            echo "npm registry: $REGISTRY"
+            echo "$REGISTRY" | grep -q socket-firewall-registry || { echo "FAIL: npm not routed through Socket Firewall"; exit 1; }
+      - run:
           name: Install dependencies
           command: |
             corepack enable
@@ -208,6 +214,12 @@ jobs:
     executor: default
     steps:
       - checkout
+      - run:
+          name: Verify Socket Firewall registry is active
+          command: |
+            REGISTRY=$(npm config get registry)
+            echo "npm registry: $REGISTRY"
+            echo "$REGISTRY" | grep -q socket-firewall-registry || { echo "FAIL: npm not routed through Socket Firewall"; exit 1; }
       - run:
           name: Add npm registry auth key
           command: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+registry = https://socket-firewall-registry.corporate.intercom.io/npm
+//socket-firewall-registry.corporate.intercom.io/npm/:_authToken = "BYUi5HGeKW4GPN1z6PXqjeo3IVmLJ9uFA8TQFzoP2VbRt3h0J9AMaqz9A"
+strict-ssl = true
+always-auth = true


### PR DESCRIPTION
### Why?

Route npm package installs through Socket Firewall's supply-chain security proxy for transparent dependency scanning.

### How?

Add `.npmrc` pointing the npm registry at Socket Firewall's npm proxy. All package installs are transparently scanned for supply-chain risks.

<sub>Generated with Claude Code</sub>