### PR TITLE
Use environment variable for npm registry auth token

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 registry = https://socket-firewall-registry.corporate.intercom.io/npm
-//socket-firewall-registry.corporate.intercom.io/npm/:_authToken = "BYUi5HGeKW4GPN1z6PXqjeo3IVmLJ9uFA8TQFzoP2VbRt3h0J9AMaqz9A"
+//socket-firewall-registry.corporate.intercom.io/npm/:_authToken = ${SOCKET_FIREWALL_NPM_TOKEN}
 strict-ssl = true
 always-auth = true


### PR DESCRIPTION
### Why?

Inline tokens in config files are a credential management anti-pattern. Environment variables are the standard approach for CI/CD credential injection.

### How?

Updates `.npmrc` to reference the registry auth token via an environment variable instead of an inline value.

<sub>Generated with Claude Code</sub>