### PR TITLE
chore: update Intercom SDK dependencies (Android: 18.1.0 → 18.2.0)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,6 +84,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:24.1.2"
-  implementation 'io.intercom.android:intercom-sdk:18.1.0'
-  implementation 'io.intercom.android:intercom-sdk-ui:18.1.0'
+  implementation 'io.intercom.android:intercom-sdk:18.2.0'
+  implementation 'io.intercom.android:intercom-sdk-ui:18.2.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
- Updated Android SDK from 18.1.0 to 18.2.0
- Bumped version from 10.1.0 to 10.2.0 (minor)
- Updated lockfiles and example projects