### PR TITLE
app.plugin.js requires @expo/config-plugins but it's only in devDepen…

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,8 +102,14 @@
     "typescript": "5.0.4"
   },
   "peerDependencies": {
+    "@expo/config-plugins": "*",
     "react": "*",
     "react-native": "*"
+  },
+  "peerDependenciesMeta": {
+    "@expo/config-plugins": {
+      "optional": true
+    }
   },
   "workspaces": [
     "examples/*",


### PR DESCRIPTION
…dencies

this breaks isolated installs and Expo prebuild under pnpm / Bun globalStore

@intercom/intercom-react-native@10.0.1 ships app.plugin.js (the Expo config plugin entry) which loads lib/commonjs/expo-plugins/index.js. That file does:

  const { withPlugins, ... } = require('@expo/config-plugins');

  But @expo/config-plugins is declared only under devDependencies in package.json. With hoisted installs it works by accident - @expo/config-plugins happens to be hoisted from expo to the project root. Under isolated layouts (pnpm strict, Yarn PnP, Bun globalStore = true) the package  can only resolve its declared runtime deps, so it crashes:

  PluginError: Cannot find module '@expo/config-plugins'
  Require stack:
  - <store>/@intercom+intercom-react-native@10.0.1/.../lib/commonjs/expo-plugins/index.js
  - <store>/@intercom+intercom-react-native@10.0.1/.../app.plugin.js
  - ...

  Repro
  
  - Expo 56 app with @intercom/intercom-react-native installed.
  - bun install with bunfig.toml containing globalStore = true, then bun expo start (or expo prebuild).
  - Crashes when Expo loads the plugin.

  Suggested fix

  Move @expo/config-plugins to peerDependencies (optional, since bare RN consumers don't need it):

  "peerDependencies": {
    "@expo/config-plugins": "*", "react": "*", "react-native": "*" }, "peerDependenciesMeta": { "@expo/config-plugins": { "optional": true } }

  @expo/config-plugins is bundled with expo, so any Expo  consumer already has a usable instance - peerDep is the correct contract.

  Environment

  - @intercom/intercom-react-native 10.0.1
  - expo 56.0.5, @expo/config-plugins (bundled via expo)
  - bun 1.3.14 with globalStore = true