### PR TITLE
chore: probe zizmor compliance

### DIFF
--- a/.github/workflows/zizmor-scan.yml
+++ b/.github/workflows/zizmor-scan.yml
@@ -1,0 +1,24 @@
+name: Zizmor Workflow Security Scan
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/**
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        run: pip install zizmor==1.25.2
+
+      - name: Scan workflows
+        run: zizmor --min-severity=medium .github/workflows/


### PR DESCRIPTION
Probe PR to surface Zizmor findings ahead of the org enabling a mandatory ruleset on every PR.

If the scan passes, this PR will be closed and the branch deleted -- no changes land.
If the scan reports findings, the probe workflow file will be removed from this branch and the actual fixes will replace it before review.

<sub>Generated with Claude Code</sub>