### PR TITLE
Add Dependabot github-actions ecosystem with cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # Keeps SHA-pinned GitHub Actions current. Cooldown delays adoption of newly
+  # published versions so malicious releases have time to be caught and yanked
+  # before we pull them in. Note: GitHub does not generate security advisories
+  # for SHA-pinned actions, so all updates go through the cooldown window.
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    schedule:
+      interval: "daily"
+      time: "12:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 6
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels:
+      - "dependabot-version-update"
+      - "github-actions"


### PR DESCRIPTION
### Why?

Action `uses:` references in this repo are SHA-pinned by policy, but nothing keeps those pins current. This enables daily SHA bumps (and refreshed `# vX.Y.Z` comments) for GitHub Actions, with a 7-day cooldown window to mitigate supply-chain risk from newly-published malicious versions before we adopt them.

### How?

Adds `.github/dependabot.yml` enabling the `github-actions` ecosystem on a daily schedule with a 7-day default cooldown, grouped updates, and a per-run PR cap.

<sub>Generated with Claude Code</sub>