### PR TITLE
fix(android): guard deconstructRegistration against null Registration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,6 +68,13 @@ android {
       }
     }
   }
+
+  testOptions {
+    unitTests {
+      includeAndroidResources = false
+      returnDefaultValues = true
+    }
+  }
 }
 
 repositories {
@@ -86,4 +93,7 @@ dependencies {
   implementation "com.google.firebase:firebase-messaging:24.1.2"
   implementation 'io.intercom.android:intercom-sdk:18.2.0'
   implementation 'io.intercom.android:intercom-sdk-ui:18.2.0'
+
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.mockito:mockito-core:5.11.0'
 }

--- a/android/src/main/java/com/intercom/reactnative/IntercomHelpers.java
+++ b/android/src/main/java/com/intercom/reactnative/IntercomHelpers.java
@@ -248,6 +248,9 @@ public class IntercomHelpers {
 
   public static WritableMap deconstructRegistration(Registration registration) {
     WritableMap registrationMap = Arguments.createMap();
+    if (registration == null) {
+      return registrationMap;
+    }
     if (registration.getEmail() != null) {
       registrationMap.putString("email", registration.getEmail());
     }

--- a/android/src/test/java/com/intercom/reactnative/IntercomHelpersTest.java
+++ b/android/src/test/java/com/intercom/reactnative/IntercomHelpersTest.java
@@ -1,0 +1,63 @@
+package com.intercom.reactnative;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.JavaOnlyMap;
+import com.facebook.react.bridge.WritableMap;
+
+import io.intercom.android.sdk.identity.Registration;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class IntercomHelpersTest {
+
+  private MockedStatic<Arguments> argumentsMock;
+
+  @Before
+  public void setUp() {
+    argumentsMock = mockStatic(Arguments.class);
+    argumentsMock.when(Arguments::createMap).thenAnswer(invocation -> new JavaOnlyMap());
+  }
+
+  @After
+  public void tearDown() {
+    argumentsMock.close();
+  }
+
+  // Regression guard for intercom/intercom#520691: a null Registration arrives here whenever
+  // Intercom.client().fetchLoggedInUserAttributes() returns null (no logged-in user, app
+  // re-launched after OS kill, etc.). Before the fix, this crashed the host process with
+  // NullPointerException on registration.getEmail().
+  @Test
+  public void deconstructRegistration_returnsEmptyMap_whenRegistrationIsNull() {
+    WritableMap result = IntercomHelpers.deconstructRegistration(null);
+
+    assertNotNull("expected an empty map, not null", result);
+    JavaOnlyMap map = (JavaOnlyMap) result;
+    assertFalse("expected no email key when registration is null", map.hasKey("email"));
+    assertFalse("expected no userId key when registration is null", map.hasKey("userId"));
+  }
+
+  @Test
+  public void deconstructRegistration_returnsBothFields_whenRegistrationIsFullyPopulated() {
+    Registration registration = new Registration()
+        .withEmail("test@example.com")
+        .withUserId("user-42");
+
+    WritableMap result = IntercomHelpers.deconstructRegistration(registration);
+    JavaOnlyMap map = (JavaOnlyMap) result;
+
+    assertTrue(map.hasKey("email"));
+    assertEquals("test@example.com", map.getString("email"));
+    assertTrue(map.hasKey("userId"));
+    assertEquals("user-42", map.getString("userId"));
+  }
+}


### PR DESCRIPTION
## Summary
- `Intercom.client().fetchLoggedInUserAttributes()` returns `null` when no user is registered (OS killed the app, user not yet registered, etc.). The Android RN bridge passed that `null` directly into `IntercomHelpers.deconstructRegistration`, which dereferenced it via `registration.getEmail()` and crashed the process with `NullPointerException`.
- This patch returns an empty `WritableMap` when `registration` is `null`, matching the iOS bridge's nil-handling in `IntercomAttributesBuilder.dictionaryForUserAttributes:` (Obj-C nil-messaging makes its property reads safe and produces an empty `NSDictionary`).
- One-line defensive guard in the helper — keeps the existing JS contract ("empty object when no logged-in user") and brings Android to parity with iOS.

## Context
Reported via internal issue [intercom/intercom#520691](https://github.com/intercom/intercom/issues/520691). Customer `thndr-app` (app `3437363`) was seeing this as a fatal Android crash on production after background/lock cycles.

Pre-existing bug, not a regression — `deconstructRegistration` has never null-checked its argument across versions 9.8.0 → 10.0.2.

## Affected code paths
- `android/src/main/java/com/intercom/reactnative/IntercomHelpers.java:249` (fixed)
- Call sites that previously triggered the NPE:
  - `android/src/oldarch/IntercomModule.java:203-206`
  - `android/src/newarch/IntercomModule.java:224-228`

## Regression test
This PR also bootstraps a minimal JVM unit-test setup for the Android library (`android/build.gradle` now declares `junit:junit:4.13.2` and `org.mockito:mockito-core:5.11.0` under `testImplementation`, plus a `testOptions { unitTests { ... } }` block). A new test class `android/src/test/java/com/intercom/reactnative/IntercomHelpersTest.java` covers:

- `deconstructRegistration_returnsEmptyMap_whenRegistrationIsNull` — direct regression guard for #520691. Against the pre-fix helper this test fails with the literal production NPE `Cannot invoke "io.intercom.android.sdk.identity.Registration.getEmail()" because "registration" is null`; against the post-fix helper it passes.
- `deconstructRegistration_returnsBothFields_whenRegistrationIsFullyPopulated` — happy-path guard so the fix can't accidentally regress map population.

Run locally with:
```
cd examples/example/android
./gradlew :intercomreactnative:testDebugUnitTest
```

## Test plan
- [x] Automated: `:intercomreactnative:testDebugUnitTest` passes (2/2) against the patched helper; the null-case test fails as expected against the unpatched helper.
- [ ] Manual: call `Intercom.fetchLoggedInUserAttributes()` from JS before any `loginUser*` call on Android — should resolve to `{}` instead of crashing the app.
- [ ] Manual: kill the example app from recents, relaunch cold, call `Intercom.fetchLoggedInUserAttributes()` immediately — should resolve to `{}` and not crash.
- [ ] Regression: with a logged-in user, `Intercom.fetchLoggedInUserAttributes()` still returns the email/userId map as before.
- [ ] Parity: confirm iOS still returns an empty object for the same "no logged-in user" scenario.

<sub>Generated with Claude Code</sub>