### PR TITLE
Add OIDC trusted publishing + staged npm releases via GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+name: Publish (staged)
+
+on:
+  release:
+    types: [published]        # cutting a Release creates the tag AND fires this
+
+permissions:
+  contents: read              # workflow default (least privilege); only stage-publish also needs id-token, granted on that job
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+        with: { persist-credentials: false }
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'      # pin >= 22.14.0
+          package-manager-cache: false     # release-triggered: disable auto-cache (zizmor cache-poisoning)
+      - name: Assert Release tag matches package.json version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          PKG="$(node -p "require('./package.json').version")"
+          [ "${RELEASE_TAG#v}" = "$PKG" ] || { echo "tag $RELEASE_TAG != package.json v$PKG"; exit 1; }
+      - name: Refuse releases not on the default branch
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          git fetch origin "$DEFAULT_BRANCH" --depth=1
+          git merge-base --is-ancestor "$GITHUB_SHA" "origin/$DEFAULT_BRANCH" \
+            || { echo "release $RELEASE_TAG not reachable from $DEFAULT_BRANCH — refusing"; exit 1; }
+
+  stage-publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write           # OIDC trusted publishing: only this job mints the token
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+        with: { persist-credentials: false }
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - run: corepack enable
+      - run: yarn install --immutable
+      - run: yarn prepare
+      - run: npm install -g npm@11.15.0    # npm CLI: staged publishing needs npm >= 11.15.0
+      - name: Resolve dist-tag (a prerelease must never go to `latest`)
+        id: disttag
+        env:
+          PRERELEASE_TAG: beta
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          case "$VERSION" in
+            *-*) TAG="$PRERELEASE_TAG" ;;
+            *)   TAG="latest" ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - name: Stage publish
+        env:
+          DIST_TAG: ${{ steps.disttag.outputs.tag }}
+        run: npm stage publish --tag "$DIST_TAG"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,12 +7,18 @@ on:
 permissions:
   contents: read              # workflow default (least privilege); only stage-publish also needs id-token, granted on that job
 
+concurrency:
+  group: publish-${{ github.workflow }}   # serialize all publish runs; never two staged releases racing for a dist-tag
+  cancel-in-progress: false               # queue, don't cancel: killing a half-done `npm stage publish` is the torn state we're avoiding
+
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
-        with: { persist-credentials: false }
+        with:
+          persist-credentials: false
+          fetch-depth: 0                   # full history so origin/<default> ancestry is computable; checkout fetches authenticated before stripping creds
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'      # pin >= 22.14.0
@@ -28,13 +34,13 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          git fetch origin "$DEFAULT_BRANCH" --depth=1
           git merge-base --is-ancestor "$GITHUB_SHA" "origin/$DEFAULT_BRANCH" \
             || { echo "release $RELEASE_TAG not reachable from $DEFAULT_BRANCH — refusing"; exit 1; }
 
   stage-publish:
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 15         # bound a hung publish instead of running to the 6h default
     permissions:
       contents: read
       id-token: write           # OIDC trusted publishing: only this job mints the token

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,8 @@ permissions:
   contents: read              # workflow default (least privilege); only stage-publish also needs id-token, granted on that job
 
 concurrency:
-  group: publish-${{ github.workflow }}   # serialize all publish runs; never two staged releases racing for a dist-tag
-  cancel-in-progress: false               # queue, don't cancel: killing a half-done `npm stage publish` is the torn state we're avoiding
+  group: publish-${{ github.workflow }}   # serialize publishes; no dist-tag races
+  cancel-in-progress: false               # queue, don't kill an in-flight publish
 
 jobs:
   verify:
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
         with:
           persist-credentials: false
-          fetch-depth: 0                   # full history so origin/<default> ancestry is computable; checkout fetches authenticated before stripping creds
+          fetch-depth: 0                   # full history for the ancestry check below
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'      # pin >= 22.14.0
@@ -40,7 +40,7 @@ jobs:
   stage-publish:
     needs: verify
     runs-on: ubuntu-latest
-    timeout-minutes: 15         # bound a hung publish instead of running to the 6h default
+    timeout-minutes: 15         # cap a hung publish
     permissions:
       contents: read
       id-token: write           # OIDC trusted publishing: only this job mints the token

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0                   # full history for the ancestry check below
@@ -45,7 +45,7 @@ jobs:
       contents: read
       id-token: write           # OIDC trusted publishing: only this job mints the token
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
         with: { persist-credentials: false }
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
### Why?

Moves npm publishing onto short-lived, per-run OIDC credentials with a human approval step, removing the need for a stored long-lived npm token.

### How?

Adds a release-triggered GitHub Actions workflow that authenticates to npm via OIDC (no token) and uses npm's staged publishing, so each release is queued for a maintainer to approve before it goes live.

Opened as an alternative for discussion against the existing migration:

- #360

The difference: this layers a human staged-approval gate (`npm stage publish`) on top of OIDC, rather than publishing directly on release.

<sub>Generated with Claude Code</sub>