### PR TITLE
chore: bump version to 10.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
### Why?

Prepare a 10.3.1 release of the React Native package.

### How?

Bumps the package version from 10.3.0 to 10.3.1.

<sub>Generated with Claude Code</sub>