### PR TITLE
Guard deconstructRegistration against null Registration

### DIFF
--- a/android/src/main/java/com/intercom/reactnative/IntercomHelpers.java
+++ b/android/src/main/java/com/intercom/reactnative/IntercomHelpers.java
@@ -246,8 +246,15 @@ public class IntercomHelpers {
     return value;
   }
 
-  public static WritableMap deconstructRegistration(Registration registration) {
+  public static WritableMap deconstructRegistration(@Nullable Registration registration) {
     WritableMap registrationMap = Arguments.createMap();
+    if (registration == null) {
+      // Intercom.client().fetchLoggedInUserAttributes() returns null when no user is
+      // logged in (e.g. after the OS kills and restarts the process, clearing the session).
+      // Return an empty map to match the iOS bridge, which resolves an empty dictionary
+      // for the same "no logged-in user" case instead of crashing.
+      return registrationMap;
+    }
     if (registration.getEmail() != null) {
       registrationMap.putString("email", registration.getEmail());
     }


### PR DESCRIPTION
## What

Adds a null guard at the top of `IntercomHelpers.deconstructRegistration(...)` so it returns an empty `WritableMap` when the `Registration` is `null`, instead of crashing.

## Why

`Intercom.client().fetchLoggedInUserAttributes()` returns `null` by design when no user is logged in — the native Android SDK documents this (`fetchLoggedInUserAttributes(): Registration?`). This happens, for example, after the OS kills and restarts the app process (clearing the in-memory native session) and the app calls `fetchLoggedInUserAttributes()` before re-registration completes.

Both `oldarch` and `newarch` `IntercomModule.fetchLoggedInUserAttributes()` pass that return value straight into `deconstructRegistration(...)`:

```java
Registration registration = Intercom.client().fetchLoggedInUserAttributes(); // can be null
promise.resolve(IntercomHelpers.deconstructRegistration(registration));       // no null check
```

`deconstructRegistration` then dereferences `registration.getEmail()` on its first line, throwing a fatal `NullPointerException` on the JS bridge thread (`UncaughtExceptionHandler` → process death).

This is a **platform parity gap**: the iOS bridge (`IntercomAttributesBuilder.dictionaryForUserAttributes:`) reads attributes on a possibly-nil `ICMUserAttributes` and, thanks to Obj-C nil-messaging, resolves an empty dictionary (`{}`) for the same "no logged-in user" case. The fix brings Android to the same behavior, which also satisfies the existing non-nullable TS contract `fetchLoggedInUserAttributes: () => Promise<UserAttributes>`.

The native Android SDK is correct and unchanged — the nullable return is by design; only the RN bridge needed the guard. Pre-existing bug, not a regression (present in every release from 9.8.0 onward).

## Crash (production)

```
java.lang.NullPointerException: Attempt to invoke virtual method
'java.lang.String io.intercom.android.sdk.identity.Registration.getEmail()' on a null object reference
  at com.intercom.reactnative.IntercomHelpers.deconstructRegistration
  at com.intercom.reactnative.IntercomModule.fetchLoggedInUserAttributes
```

## Tests

The `android/` library module has no JUnit/Robolectric test harness, and `deconstructRegistration` depends on RN's `Arguments.createMap()` bridge runtime. Standing up a test harness is out of scope for this one-line fix; the change is a straightforward null guard with a behavior matching the already-shipped iOS path.

## Related

- Internal issue: intercom/intercom#520691

[~ Automated via Claude](https://github.com/intercom/claude-plugins/blob/main/plugins/base/docs/external-message-attribution.md)