### PR TITLE
chore: bump version to 10.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "10.3.1",
+  "version": "10.3.2",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
### Why?

Prepare a 10.3.2 release of the React Native package.

This release includes the fix from #451: a null guard in `IntercomHelpers.deconstructRegistration(...)` so `fetchLoggedInUserAttributes()` returns an empty map instead of crashing with a `NullPointerException` when no user is logged in (e.g. after the OS kills and restarts the app process before re-registration completes).

### How?

Bumps the package version from 10.3.1 to 10.3.2.

<sub>Generated with Claude Code</sub>