### PR TITLE
chore: update Intercom SDK dependencies (Android: 18.3.0 → 18.3.1)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,6 +84,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:24.1.2"
-  implementation 'io.intercom.android:intercom-sdk:18.3.0'
-  implementation 'io.intercom.android:intercom-sdk-ui:18.3.0'
+  implementation 'io.intercom.android:intercom-sdk:18.3.1'
+  implementation 'io.intercom.android:intercom-sdk-ui:18.3.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "10.3.2",
+  "version": "10.3.3",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## 🔄 Intercom SDK Dependency Update

Prepares the next RN release. Modeled on #448.

### 📋 Changes Made:
- Updated Android SDK from `18.3.0` to `18.3.1`
- iOS SDK unchanged — already at the latest (`19.6.3`)
- Bumped version from `10.3.2` to `10.3.3` (patch)

### 📚 Release Notes:

#### 🤖 Android SDK 18.3.1
[View Release Notes](https://github.com/intercom/intercom-android/releases/tag/18.3.1)

```
###### Release Date: 23-06-2026

### 🐛 Bug Fixes
* Fixed a crash when selecting multiple photos to upload from a Messenger form
* Fixed attribute collectors not appearing in Android conversations
* Fixed a crash caused by push-notification image loading running on the main thread
* Restored the `ThemeMode` enum and `ui` package to the published artifact, so theme customization works as documented
* Fixed Fin reply links rendering with unreadable, low-contrast text

### 👉 Dependency updates
* Firebase Messaging: Updated to 25.1.0
```

### 📝 Notes
- Version bumped as a **patch** (`10.3.3`): this round is bug-fixes-only on a single platform. #448 was a minor bump because it carried a minor Android feature release.
- `Podfile.lock` files are left untouched — the iOS `Intercom` pod is unchanged, and lock files are regenerated by `pod install` on CI.

[~ Automated via Claude](https://github.com/intercom/claude-plugins/blob/main/plugins/base/docs/external-message-attribution.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)