### PR TITLE
chore: update Intercom SDK dependencies (iOS: 19.6.3 → 19.6.4, Android: 18.3.1 → 18.3.2)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,6 +84,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:24.1.2"
-  implementation 'io.intercom.android:intercom-sdk:18.3.1'
-  implementation 'io.intercom.android:intercom-sdk-ui:18.3.1'
+  implementation 'io.intercom.android:intercom-sdk:18.3.2'
+  implementation 'io.intercom.android:intercom-sdk-ui:18.3.2'
 }

--- a/examples/example/ios/Podfile.lock
+++ b/examples/example/ios/Podfile.lock
@@ -8,15 +8,15 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - Intercom (19.6.3)
-  - intercom-react-native (10.3.0):
+  - Intercom (19.6.4)
+  - intercom-react-native (10.3.4):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - Intercom (~> 19.6.3)
+    - Intercom (~> 19.6.4)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2560,8 +2560,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  Intercom: 84e1c5107a16805ddfd8e7e413446a206839ddb0
-  intercom-react-native: e30de390785d8c976396e768111ce5179078bffa
+  Intercom: 74f3d48568d61f70c5bbcbcf2a07567a4349c4fc
+  intercom-react-native: 7573fd7ba9c1f23ab96de02dcd0bfb5033e7903a
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a

--- a/examples/with-notifications/ios/Podfile.lock
+++ b/examples/with-notifications/ios/Podfile.lock
@@ -8,15 +8,15 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - Intercom (19.6.3)
-  - intercom-react-native (10.2.0):
+  - Intercom (19.6.4)
+  - intercom-react-native (10.3.4):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - Intercom (~> 19.6.3)
+    - Intercom (~> 19.6.4)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2773,8 +2773,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  Intercom: 84e1c5107a16805ddfd8e7e413446a206839ddb0
-  intercom-react-native: 5c4ab5eee021eeb80b3a20fb3e8e558eba1d0514
+  Intercom: 74f3d48568d61f70c5bbcbcf2a07567a4349c4fc
+  intercom-react-native: 7573fd7ba9c1f23ab96de02dcd0bfb5033e7903a
   MMKV: 7b5df6a8bf785c6705cc490c541b9d8a957c4a64
   MMKVCore: 3f40b896e9ab522452df9df3ce983471aa2449ba
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f

--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
-  s.dependency "Intercom", '~> 19.6.3'
+  s.dependency "Intercom", '~> 19.6.4'
 
   is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
   folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "10.3.3",
+  "version": "10.3.4",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
### Why?

Keep `intercom-react-native`'s bundled native SDKs current with the latest Intercom iOS ([19.6.4](https://github.com/intercom/intercom-ios/releases/tag/19.6.4)) and Android ([18.3.2](https://github.com/intercom/intercom-android/releases/tag/18.3.2)) releases, so consumers of this wrapper pick up the associated fixes.

### How?

Bump the iOS podspec dependency and Android Gradle dependency to the new SDK versions, bump the package version to match, and regenerate the example apps' `Podfile.lock` files that the version-bump automation missed.

<sub>Generated with Claude Code</sub>