### PR TITLE
feat: add suppressProactiveContent for pre-auth carousel/survey visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,22 @@ Toggles visibility of in-app messages.
 
 ---
 
+### `Intercom.suppressProactiveContent(types)`
+
+Suppresses the given proactive content types (carousels and/or surveys). All proactive content is visible by default. Pass an empty array to unsuppress all types.
+
+### Options
+
+| Type  | Type                                          | Required |
+| ----- | --------------------------------------------- | -------- |
+| types | array of strings `CAROUSEL, SURVEY`           | yes      |
+
+### Returns
+
+`Promise<boolean>`
+
+---
+
 ### `Intercom.setLauncherVisibility(visibility)`
 
 Toggles visibility of the launcher view. Set as Intercom.Visibility.GONE to hide the launcher when you don't want it to

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,6 +84,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:24.1.2"
-  implementation 'io.intercom.android:intercom-sdk:18.3.2'
-  implementation 'io.intercom.android:intercom-sdk-ui:18.3.2'
+  implementation 'io.intercom.android:intercom-sdk:18.5.0'
+  implementation 'io.intercom.android:intercom-sdk-ui:18.5.0'
 }

--- a/android/src/main/java/com/intercom/reactnative/IntercomErrorCodes.java
+++ b/android/src/main/java/com/intercom/reactnative/IntercomErrorCodes.java
@@ -17,6 +17,7 @@ public class IntercomErrorCodes {
   public static final String DISPLAY_CONTENT = "203";
   public static final String SET_IN_APP_MESSAGE_VISIBILITY = "205";
   public static final String HIDE_INTERCOM = "206";
+  public static final String SUPPRESS_PROACTIVE_CONTENT = "207";
   public static final String SET_LAUNCHER_VISIBILITY = "208";
   public static final String SET_BOTTOM_PADDING = "209";
   public static final String SET_THEME_MODE = "210";

--- a/android/src/newarch/IntercomModule.java
+++ b/android/src/newarch/IntercomModule.java
@@ -11,12 +11,14 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.module.annotations.ReactModule;
 import com.google.firebase.messaging.RemoteMessage;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -492,6 +494,28 @@ public class IntercomModule extends NativeIntercomSpecSpec {
       Log.e(NAME, "setInAppMessageVisibility error:");
       Log.e(NAME, err.toString());
       promise.reject(IntercomErrorCodes.SET_IN_APP_MESSAGE_VISIBILITY, err.toString());
+    }
+  }
+
+  @ReactMethod
+  public void suppressProactiveContent(ReadableArray types, Promise promise) {
+    try {
+      List<Intercom.ContentType> contentTypes = new ArrayList<>();
+      for (int i = 0; i < types.size(); i++) {
+        String type = types.getString(i);
+        if ("CAROUSEL".equals(type)) {
+          contentTypes.add(Intercom.ContentType.CAROUSEL);
+        } else if ("SURVEY".equals(type)) {
+          contentTypes.add(Intercom.ContentType.SURVEY);
+        }
+      }
+      Intercom.client().suppressProactiveContent(contentTypes);
+      Log.d(NAME, "suppressProactiveContent");
+      promise.resolve(true);
+    } catch (Exception err) {
+      Log.e(NAME, "suppressProactiveContent error:");
+      Log.e(NAME, err.toString());
+      promise.reject(IntercomErrorCodes.SUPPRESS_PROACTIVE_CONTENT, err.toString());
     }
   }
 

--- a/android/src/oldarch/IntercomModule.java
+++ b/android/src/oldarch/IntercomModule.java
@@ -11,12 +11,14 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.module.annotations.ReactModule;
 import com.google.firebase.messaging.RemoteMessage;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -470,6 +472,28 @@ public class IntercomModule extends ReactContextBaseJavaModule {
       Log.e(NAME, "setInAppMessageVisibility error:");
       Log.e(NAME, err.toString());
       promise.reject(IntercomErrorCodes.SET_IN_APP_MESSAGE_VISIBILITY, err.toString());
+    }
+  }
+
+  @ReactMethod
+  public void suppressProactiveContent(ReadableArray types, Promise promise) {
+    try {
+      List<Intercom.ContentType> contentTypes = new ArrayList<>();
+      for (int i = 0; i < types.size(); i++) {
+        String type = types.getString(i);
+        if ("CAROUSEL".equals(type)) {
+          contentTypes.add(Intercom.ContentType.CAROUSEL);
+        } else if ("SURVEY".equals(type)) {
+          contentTypes.add(Intercom.ContentType.SURVEY);
+        }
+      }
+      Intercom.client().suppressProactiveContent(contentTypes);
+      Log.d(NAME, "suppressProactiveContent");
+      promise.resolve(true);
+    } catch (Exception err) {
+      Log.e(NAME, "suppressProactiveContent error:");
+      Log.e(NAME, err.toString());
+      promise.reject(IntercomErrorCodes.SUPPRESS_PROACTIVE_CONTENT, err.toString());
     }
   }
 

--- a/examples/example/ios/Podfile.lock
+++ b/examples/example/ios/Podfile.lock
@@ -8,15 +8,15 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - Intercom (19.6.4)
-  - intercom-react-native (10.3.4):
+  - Intercom (19.7.0)
+  - intercom-react-native (10.4.0):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - Intercom (~> 19.6.4)
+    - Intercom (~> 19.7.0)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2560,8 +2560,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  Intercom: 74f3d48568d61f70c5bbcbcf2a07567a4349c4fc
-  intercom-react-native: 7573fd7ba9c1f23ab96de02dcd0bfb5033e7903a
+  Intercom: a14e32c294ee3402cb0adddacf3de8b22730d779
+  intercom-react-native: 6e11ae0c7a0e29ec01ed281bd1953e89c9296b7c
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a

--- a/examples/with-notifications/ios/Podfile.lock
+++ b/examples/with-notifications/ios/Podfile.lock
@@ -8,15 +8,15 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - Intercom (19.6.4)
-  - intercom-react-native (10.3.4):
+  - Intercom (19.7.0)
+  - intercom-react-native (10.4.0):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - Intercom (~> 19.6.4)
+    - Intercom (~> 19.7.0)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2773,8 +2773,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  Intercom: 74f3d48568d61f70c5bbcbcf2a07567a4349c4fc
-  intercom-react-native: 7573fd7ba9c1f23ab96de02dcd0bfb5033e7903a
+  Intercom: a14e32c294ee3402cb0adddacf3de8b22730d779
+  intercom-react-native: 6e11ae0c7a0e29ec01ed281bd1953e89c9296b7c
   MMKV: 7b5df6a8bf785c6705cc490c541b9d8a957c4a64
   MMKVCore: 3f40b896e9ab522452df9df3ce983471aa2449ba
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f

--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
-  s.dependency "Intercom", '~> 19.6.4'
+  s.dependency "Intercom", '~> 19.7.0'
 
   is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
   folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'

--- a/ios/IntercomModule.m
+++ b/ios/IntercomModule.m
@@ -374,6 +374,25 @@ RCT_EXPORT_METHOD(setInAppMessageVisibility:(NSString *)visibility
     resolve(@(YES));
 };
 
+RCT_EXPORT_METHOD(suppressProactiveContent:(NSArray *)types
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+
+    NSMutableArray<NSNumber *> *mappedTypes = [NSMutableArray array];
+    for (id type in types) {
+        if (![type isKindOfClass:[NSString class]]) {
+            continue;
+        }
+        if ([type isEqualToString:@"CAROUSEL"]) {
+            [mappedTypes addObject:@(IntercomProactiveContentTypeCarousel)];
+        } else if ([type isEqualToString:@"SURVEY"]) {
+            [mappedTypes addObject:@(IntercomProactiveContentTypeSurvey)];
+        }
+    }
+    [Intercom suppressProactiveContent:mappedTypes];
+    resolve(@(YES));
+};
+
 
 #pragma mark - Unread Conversation Count
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "10.3.4",
+  "version": "10.4.0",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/NativeIntercomSpec.ts
+++ b/src/NativeIntercomSpec.ts
@@ -78,6 +78,7 @@ export interface Spec extends TurboModule {
   hideIntercom(): Promise<boolean>;
   setBottomPadding(paddingBottom: number): Promise<boolean>;
   setInAppMessageVisibility(visibility: string): Promise<boolean>;
+  suppressProactiveContent(types: string[]): Promise<boolean>;
   setLauncherVisibility(visibility: string): Promise<boolean>;
   setNeedsStatusBarAppearanceUpdate(): Promise<boolean>;
   sendTokenToIntercom(token: string): Promise<boolean>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -237,6 +237,14 @@ export type IntercomType = {
   setInAppMessageVisibility(visibility: VisibilityType): Promise<boolean>;
 
   /**
+   * Suppress the given proactive content types (carousels and/or surveys).
+   * @note All proactive content is visible by default. Pass an empty array to unsuppress all types.
+   *
+   * @param types The proactive content types to suppress.
+   */
+  suppressProactiveContent(types: ProactiveContentType[]): Promise<boolean>;
+
+  /**
    * Show or hide the Intercom Launcher in your app.
    * @note The Launcher is hidden by default.
    *
@@ -389,6 +397,8 @@ const Intercom: IntercomType = {
     IntercomModule.setBottomPadding(paddingBottom),
   setInAppMessageVisibility: (visibility) =>
     IntercomModule.setInAppMessageVisibility(visibility),
+  suppressProactiveContent: (types) =>
+    IntercomModule.suppressProactiveContent(types),
   setLauncherVisibility: (visibility) =>
     IntercomModule.setLauncherVisibility(visibility),
 
@@ -420,6 +430,11 @@ const Intercom: IntercomType = {
 };
 
 export default Intercom;
+
+export enum ProactiveContentType {
+  Carousel = 'CAROUSEL',
+  Survey = 'SURVEY',
+}
 
 export enum ContentType {
   Article = 'ARTICLE',


### PR DESCRIPTION
### Why?

Apps embedding the Messenger need to suppress specific proactive content types — carousels and surveys — during their pre-authentication launch flow, so proactive content doesn't surface before a user is identified. This was validated via a prerelease build; this PR is the proper release.

### How?

Bumps the bundled native SDKs to the releases that expose the API (iOS 19.7.0, Android 18.5.0) and wires `suppressProactiveContent(types)` from the JS API through to the native `suppressProactiveContent` on both platforms.

<sub>Generated with Claude Code</sub>