### PR TITLE
chore: update Intercom SDK dependencies (iOS: 19.7.0 → 19.7.1, Android: 18.5.0 → 18.6.0)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,6 +84,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:24.1.2"
-  implementation 'io.intercom.android:intercom-sdk:18.5.0'
-  implementation 'io.intercom.android:intercom-sdk-ui:18.5.0'
+  implementation 'io.intercom.android:intercom-sdk:18.6.0'
+  implementation 'io.intercom.android:intercom-sdk-ui:18.6.0'
 }

--- a/examples/example/ios/Podfile.lock
+++ b/examples/example/ios/Podfile.lock
@@ -8,15 +8,15 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - Intercom (19.7.0)
-  - intercom-react-native (10.4.0):
+  - Intercom (19.7.1)
+  - intercom-react-native (10.5.0):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - Intercom (~> 19.7.0)
+    - Intercom (~> 19.7.1)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2560,8 +2560,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  Intercom: a14e32c294ee3402cb0adddacf3de8b22730d779
-  intercom-react-native: 6e11ae0c7a0e29ec01ed281bd1953e89c9296b7c
+  Intercom: c21e5c4adb1546da3b8bcdbeb50f64a30e5a7f3e
+  intercom-react-native: 995f357405b92eb132a2ff699f9b0c2aa76746e5
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a

--- a/examples/with-notifications/ios/Podfile.lock
+++ b/examples/with-notifications/ios/Podfile.lock
@@ -8,15 +8,15 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - Intercom (19.7.0)
-  - intercom-react-native (10.4.0):
+  - Intercom (19.7.1)
+  - intercom-react-native (10.5.0):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - Intercom (~> 19.7.0)
+    - Intercom (~> 19.7.1)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2773,8 +2773,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  Intercom: a14e32c294ee3402cb0adddacf3de8b22730d779
-  intercom-react-native: 6e11ae0c7a0e29ec01ed281bd1953e89c9296b7c
+  Intercom: c21e5c4adb1546da3b8bcdbeb50f64a30e5a7f3e
+  intercom-react-native: 995f357405b92eb132a2ff699f9b0c2aa76746e5
   MMKV: 7b5df6a8bf785c6705cc490c541b9d8a957c4a64
   MMKVCore: 3f40b896e9ab522452df9df3ce983471aa2449ba
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f

--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
-  s.dependency "Intercom", '~> 19.7.0'
+  s.dependency "Intercom", '~> 19.7.1'
 
   is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
   folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "10.4.0",
+  "version": "10.5.0",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
### Why?

Keep `intercom-react-native`'s bundled native SDKs current with the latest Intercom
Android ([18.6.0](https://github.com/intercom/intercom-android/releases/tag/18.6.0))
and iOS ([19.7.1](https://github.com/intercom/intercom-ios/releases/tag/19.7.1))
releases, so consumers of this wrapper pick up the associated fixes — notably the
Android ANR during `Intercom.initialize()` and the iOS launch crash on iOS 15 and 16.

### How?

Bump the Android Gradle dependency and the iOS podspec dependency to the new SDK
versions, bump the package to 10.5.0 (minor, tracking Android's minor bump per
`semver.js analyze`), and sync the example apps' `Podfile.lock` files.

The scheduled `update-dependencies` workflow computed this same update but could not
open the PR (`GitHub Actions is not permitted to create or approve pull requests`).

### Decisions

The `Podfile.lock` edits are limited to the five Intercom-attributable lines per app.
A full `pod install` also rewrites ~56 lines of React/RN codegen checksums, but that
churn reproduces on an unmodified `main` and is unrelated to this bump, so it is left
for a separate cleanup. Both new checksums were verified independently: the `Intercom`
checksum against the CocoaPods CDN podspec for 19.7.1 (method confirmed by reproducing
main's 19.7.0 value), and the `intercom-react-native` checksum from a local
`pod install` on CocoaPods 1.16.2, the version these lockfiles record.

<sub>Generated with Claude Code</sub>