### PR TITLE
fix: don't crash at import time when native modules are unavailable

### DIFF
--- a/__tests__/nativeModules.test.ts
+++ b/__tests__/nativeModules.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests that importing the native module bindings does not throw when the
+ * native side is unavailable (Expo Go, Jest, web bundles, prebuilds before
+ * pods are installed).
+ */
+
+describe('nativeModules', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.dontMock('react-native');
+  });
+
+  test('falls back to empty objects when native modules are missing', () => {
+    jest.doMock('react-native', () => ({
+      NativeModules: {},
+      TurboModuleRegistry: { get: () => null },
+    }));
+
+    let modules: typeof import('../src/nativeModules') | undefined;
+    expect(() => {
+      modules = require('../src/nativeModules');
+    }).not.toThrow();
+
+    expect(modules?.IntercomModule).toEqual({});
+    expect(modules?.IntercomEventEmitter).toEqual({});
+  });
+
+  test('uses the registered native modules when they are available', () => {
+    const intercomModule = { initialize: jest.fn() };
+    const intercomEventEmitter = { UNREAD_COUNT_CHANGE_NOTIFICATION: 'event' };
+
+    jest.doMock('react-native', () => ({
+      NativeModules: {
+        IntercomModule: intercomModule,
+        IntercomEventEmitter: intercomEventEmitter,
+      },
+      TurboModuleRegistry: { get: () => null },
+    }));
+
+    const modules = require('../src/nativeModules');
+
+    expect(modules.IntercomModule).toBe(intercomModule);
+    expect(modules.IntercomEventEmitter).toBe(intercomEventEmitter);
+  });
+});

--- a/src/nativeModules.ts
+++ b/src/nativeModules.ts
@@ -8,8 +8,9 @@ function isTurboModuleAvailable(name: string) {
   }
 }
 
-export const IntercomModule = isTurboModuleAvailable('IntercomModule')
-  ? require('./NativeIntercomSpec').default
-  : NativeModules.IntercomModule;
+export const IntercomModule =
+  (isTurboModuleAvailable('IntercomModule')
+    ? require('./NativeIntercomSpec').default
+    : NativeModules.IntercomModule) ?? {};
 
-export const IntercomEventEmitter = NativeModules.IntercomEventEmitter;
+export const IntercomEventEmitter = NativeModules.IntercomEventEmitter ?? {};


### PR DESCRIPTION
## Description

When the Intercom native module isn't available — Expo Go, Jest, a web bundle, or a prebuild before pods are installed — `NativeModules.IntercomEventEmitter` is `undefined`. Since `src/index.tsx` reads constants off it at module scope (`IntercomEventEmitter.UNREAD_COUNT_CHANGE_NOTIFICATION`, `WINDOW_DID_SHOW_NOTIFICATION`, …), merely importing the package throws:

```
TypeError: Cannot read property 'UNREAD_COUNT_CHANGE_NOTIFICATION' of undefined
```

and crashes the app at boot, before any Intercom API is called.

This PR falls back to an empty object (`?? {}`) for both `IntercomModule` and `IntercomEventEmitter`, deferring the failure from import time to the first actual API call — where callers can handle it. Behavior is completely unchanged whenever the native module exists.

We've been running this exact change as a local patch in our production React Native (Expo) app — it's what lets the package coexist with environments where the native side isn't present.

## Changes

- `src/nativeModules.ts`: `?? {}` fallback on both exports
- `__tests__/nativeModules.test.ts`: covers both paths — exports fall back to empty objects when the native module is missing (import doesn't throw), and pass through untouched when it's registered

## Verification

- `yarn typescript` ✅
- `yarn lint` ✅
- `yarn jest __tests__/nativeModules.test.ts` ✅ (2/2 passing)

## Notes

- CONTRIBUTING.md says to target `dev`, but that branch's last commit is from 2022 and all recently merged PRs target `main`, so this targets `main`. Happy to retarget if `dev` is still the intended base.
- CONTRIBUTING.md also asks for an issue first for implementation changes, but issues are disabled on this repo — so the discussion lives here.