### PR TITLE
chore: update Intercom SDK dependencies (iOS: 19.7.2 → 19.8.0, Android: 18.7.0 → 18.9.0)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,6 +84,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "com.google.firebase:firebase-messaging:24.1.2"
-  implementation 'io.intercom.android:intercom-sdk:18.7.0'
-  implementation 'io.intercom.android:intercom-sdk-ui:18.7.0'
+  implementation 'io.intercom.android:intercom-sdk:18.9.0'
+  implementation 'io.intercom.android:intercom-sdk-ui:18.9.0'
 }

--- a/examples/example/ios/Podfile.lock
+++ b/examples/example/ios/Podfile.lock
@@ -8,15 +8,15 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - Intercom (19.7.2)
-  - intercom-react-native (10.6.0):
+  - Intercom (19.8.0)
+  - intercom-react-native (10.7.0):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - Intercom (~> 19.7.2)
+    - Intercom (~> 19.8.0)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2560,8 +2560,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  Intercom: 8d5ddc9d9f186c3eaeeaf3a3125c41ebef1a0987
-  intercom-react-native: 8528a1162e21c11092030ac0d7f09f3e2acedef7
+  Intercom: e66d9a1191954141bb2dcc0e54fb7ce5393216f3
+  intercom-react-native: 493e32bab799c585acc02743f93ba1e4748c5eb6
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a

--- a/examples/with-notifications/ios/Podfile.lock
+++ b/examples/with-notifications/ios/Podfile.lock
@@ -8,15 +8,15 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - Intercom (19.7.2)
-  - intercom-react-native (10.6.0):
+  - Intercom (19.8.0)
+  - intercom-react-native (10.7.0):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - Intercom (~> 19.7.2)
+    - Intercom (~> 19.8.0)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2773,8 +2773,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  Intercom: 8d5ddc9d9f186c3eaeeaf3a3125c41ebef1a0987
-  intercom-react-native: 8528a1162e21c11092030ac0d7f09f3e2acedef7
+  Intercom: e66d9a1191954141bb2dcc0e54fb7ce5393216f3
+  intercom-react-native: 493e32bab799c585acc02743f93ba1e4748c5eb6
   MMKV: 7b5df6a8bf785c6705cc490c541b9d8a957c4a64
   MMKVCore: 3f40b896e9ab522452df9df3ce983471aa2449ba
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f

--- a/intercom-react-native.podspec
+++ b/intercom-react-native.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
-  s.dependency "Intercom", '~> 19.7.2'
+  s.dependency "Intercom", '~> 19.8.0'
 
   is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
   folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intercom/intercom-react-native",
-  "version": "10.6.0",
+  "version": "10.7.0",
   "description": "React Native wrapper to bridge our iOS and Android SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
### Why?

New versions of both native SDKs have shipped and the wrapper is behind — Android skips 18.8.0 entirely. Releasing gets users the new code block rendering, Georgian and Armenian language support, and several crash fixes.

- https://github.com/intercom/intercom-ios/releases/tag/19.8.0
- https://github.com/intercom/intercom-android/releases/tag/18.9.0
- https://github.com/intercom/intercom-android/releases/tag/18.8.0

### How?

Points both native dependencies at the latest published versions and bumps the package a minor, with the example app lockfiles re-synced to match.

<sub>Generated with Claude Code</sub>